### PR TITLE
require node 19+ to support fetch, CustomEvent, ..

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3216,6 +3216,9 @@
         "@typescript-eslint/parser": "^5.56.0",
         "ava": "^5.2.0",
         "typescript": "^5.0.4"
+      },
+      "engines": {
+        "node": ">=19.0.0"
       }
     },
     "seeds/graph-runner": {

--- a/seeds/graph-playground/package.json
+++ b/seeds/graph-playground/package.json
@@ -53,5 +53,7 @@
     "@clack/prompts": "^0.6.3",
     "@google-labs/breadboard": "*",
     "dotenv": "^16.3.1"
+  }, "engines": {
+    "node": ">=19.0.0"
   }
 }

--- a/seeds/graph-playground/package.json
+++ b/seeds/graph-playground/package.json
@@ -53,7 +53,8 @@
     "@clack/prompts": "^0.6.3",
     "@google-labs/breadboard": "*",
     "dotenv": "^16.3.1"
-  }, "engines": {
+  },
+  "engines": {
     "node": ">=19.0.0"
   }
 }


### PR DESCRIPTION
This will trigger a warning if someone – like me :( – didn't notice that they are on an ancient node.js version.
