### PR TITLE
Text classification example with leaderboard

### DIFF
--- a/seeds/gems/text_classification/20_newsgroups/train_text_classifier_embeddings.ipynb
+++ b/seeds/gems/text_classification/20_newsgroups/train_text_classifier_embeddings.ipynb
@@ -1,0 +1,1116 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Tce3stUlHN0L"
+      },
+      "source": [
+        "##### Copyright 2023 Google LLC."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "tuOe1ymfHZPu"
+      },
+      "outputs": [],
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "STuxHh6kk3eL"
+      },
+      "source": [
+        "# Training a Text Classifier Using Embeddings"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wUmTFPw2W_UD"
+      },
+      "source": [
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "          <td>\n",
+        "    <a target=\"_blank\" href=\"https://developers.generativeai.google/examples/train_text_classifier_embeddings\"><img src=\"https://developers.generativeai.google/static/site-assets/images/docs/notebook-site-button.png\" height=\"32\" width=\"32\" />View on Generative AI</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google/generative-ai-docs/blob/main/site/en/examples/train_text_classifier_embeddings.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/google/generative-ai-docs/blob/main/site/en/examples/train_text_classifier_embeddings.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bhT1u-Pof10V"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "In this notebook, you'll learn to use the embeddings produced by the PaLM API to train a model that can classify different types of newsgroup posts based on the topic.\n",
+        "\n",
+        "In this tutorial, you'll train a classifier to predict which class a newsgroup post belongs to.\n",
+        "\n",
+        "## Setup\n",
+        "\n",
+        "First, download and install the PaLM API Python library."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "FXq0ygI3BCdQ"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install -q google-generativeai"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "XiJjB2vWCQJP",
+        "outputId": "606a02ff-5e74-4142-9889-434720b9f223"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "2023-05-19 10:41:53.909089: I tensorflow/tsl/cuda/cudart_stub.cc:28] Could not find cuda drivers on your machine, GPU will not be used.\n",
+            "2023-05-19 10:41:53.953625: I tensorflow/tsl/cuda/cudart_stub.cc:28] Could not find cuda drivers on your machine, GPU will not be used.\n",
+            "2023-05-19 10:41:53.954573: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+            "To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+            "2023-05-19 10:41:54.928543: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT\n"
+          ]
+        }
+      ],
+      "source": [
+        "import google.generativeai as palm\n",
+        "\n",
+        "import re\n",
+        "import tqdm\n",
+        "import keras\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "\n",
+        "import seaborn as sns\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "from keras import layers\n",
+        "from matplotlib.ticker import MaxNLocator\n",
+        "from sklearn.datasets import fetch_20newsgroups\n",
+        "import sklearn.metrics as skmetrics"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_mwJYXpElYJc"
+      },
+      "source": [
+        "### Get an API Key\n",
+        "\n",
+        "To get started, you'll need to [create an API key](https://developers.generativeai.google/tutorials/setup)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "tayrk_A2lZ7A"
+      },
+      "outputs": [],
+      "source": [
+        "palm.configure(api_key='YOUR_API_KEY')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WKXa-Pf9lv4H"
+      },
+      "source": [
+        "Key Point: Next, you will choose a model. Any embedding model will work for this tutorial, but for real applications it's important to choose a specific model and stick with it. The outputs of different models are not compatible with each other."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "l1pfEvNflvYV"
+      },
+      "outputs": [],
+      "source": [
+        "models = [m for m in palm.list_models() if 'embedText' in m.supported_generation_methods]\n",
+        "\n",
+        "model = models[0]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "C5B9sWq0hNEV"
+      },
+      "source": [
+        "## Dataset\n",
+        "\n",
+        "The [20 Newsgroups Text Dataset](https://scikit-learn.org/0.19/datasets/twenty_newsgroups.html){:.external} contains 18,000 newsgroups posts on 20 topics divided into training and test sets. The split between the training and test datasets are based on messages posted before and after a specific date. For this tutorial, you will be using the subsets of the training and test datasets. You will preprocess and organize the data into Pandas dataframes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "jDoKis4om-Ea",
+        "outputId": "d3a36d1e-baac-4b69-f8fa-1be778ce71f9"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "['alt.atheism',\n",
+              " 'comp.graphics',\n",
+              " 'comp.os.ms-windows.misc',\n",
+              " 'comp.sys.ibm.pc.hardware',\n",
+              " 'comp.sys.mac.hardware',\n",
+              " 'comp.windows.x',\n",
+              " 'misc.forsale',\n",
+              " 'rec.autos',\n",
+              " 'rec.motorcycles',\n",
+              " 'rec.sport.baseball',\n",
+              " 'rec.sport.hockey',\n",
+              " 'sci.crypt',\n",
+              " 'sci.electronics',\n",
+              " 'sci.med',\n",
+              " 'sci.space',\n",
+              " 'soc.religion.christian',\n",
+              " 'talk.politics.guns',\n",
+              " 'talk.politics.mideast',\n",
+              " 'talk.politics.misc',\n",
+              " 'talk.religion.misc']"
+            ]
+          },
+          "execution_count": 6,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "newsgroups_train = fetch_20newsgroups(subset='train')\n",
+        "newsgroups_test = fetch_20newsgroups(subset='test')\n",
+        "\n",
+        "# View list of class names for dataset\n",
+        "newsgroups_train.target_names"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hDz9MjkNl_FD"
+      },
+      "source": [
+        "Here is an example of what a data point from the training set looks like."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "FPq-56AimOPX",
+        "outputId": "36b6de52-4298-4a31-f6d8-0506c4525707"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Lines: 15\n",
+            "\n",
+            " I was wondering if anyone out there could enlighten me on this car I saw\n",
+            "the other day. It was a 2-door sports car, looked to be from the late 60s/\n",
+            "early 70s. It was called a Bricklin. The doors were really small. In addition,\n",
+            "the front bumper was separate from the rest of the body. This is \n",
+            "all I know. If anyone can tellme a model name, engine specs, years\n",
+            "of production, where this car is made, history, or whatever info you\n",
+            "have on this funky looking car, please e-mail.\n",
+            "\n",
+            "Thanks,\n",
+            "- IL\n",
+            "   ---- brought to you by your neighborhood Lerxst ----\n",
+            "\n",
+            "\n",
+            "\n",
+            "\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "idx = newsgroups_train.data[0].index('Lines')\n",
+        "print(newsgroups_train.data[0][idx:])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "A9-DD7wgCx8j"
+      },
+      "source": [
+        "Now you will begin preprocessing the data for this tutorial. Remove any sensitive information like names, email, or redundant parts of the text like `\"From: \"` and `\"\\nSubject: \"`. Organize the information into a Pandas dataframe so it is more readable."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "urpLwp3UmPF3"
+      },
+      "outputs": [],
+      "source": [
+        "def preprocess_newsgroup_data(newsgroup_dataset):\n",
+        "  # Apply functions to remove names, emails, and extraneous words from data points in newsgroups.data\n",
+        "  newsgroup_dataset.data = [re.sub(r'[\\w\\.-]+@[\\w\\.-]+', '', d) for d in newsgroup_dataset.data] # Remove email\n",
+        "  newsgroup_dataset.data = [re.sub(r\"\\([^()]*\\)\", \"\", d) for d in newsgroup_dataset.data] # Remove names\n",
+        "  newsgroup_dataset.data = [d.replace(\"From: \", \"\") for d in newsgroup_dataset.data] # Remove \"From: \"\n",
+        "  newsgroup_dataset.data = [d.replace(\"\\nSubject: \", \"\") for d in newsgroup_dataset.data] # Remove \"\\nSubject: \"\n",
+        "\n",
+        "  # Put data points into dataframe\n",
+        "  df_processed = pd.DataFrame(newsgroup_dataset.data, columns=['Text'])\n",
+        "  df_processed['Label'] = newsgroup_dataset.target\n",
+        "  # Match label to target name index\n",
+        "  df_processed['Class Name'] = ''\n",
+        "  for idx, row in df_processed.iterrows():\n",
+        "    df_processed.at[idx, 'Class Name'] = newsgroup_dataset.target_names[row['Label']]\n",
+        "\n",
+        "  return df_processed"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "JMKddQdNnAOV",
+        "outputId": "7bbf837c-0713-4865-a293-e2528abf8a41"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>Text</th>\n",
+              "      <th>Label</th>\n",
+              "      <th>Class Name</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>WHAT car is this!?\\nNntp-Posting-Host: rac3.w...</td>\n",
+              "      <td>7</td>\n",
+              "      <td>rec.autos</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>SI Clock Poll - Final Call\\nSummary: Final ca...</td>\n",
+              "      <td>4</td>\n",
+              "      <td>comp.sys.mac.hardware</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>PB questions...\\nOrganization: Purdue Univers...</td>\n",
+              "      <td>4</td>\n",
+              "      <td>comp.sys.mac.hardware</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>Re: Weitek P9000 ?\\nOrganization: Harris Comp...</td>\n",
+              "      <td>1</td>\n",
+              "      <td>comp.graphics</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>Re: Shuttle Launch Question\\nOrganization: Sm...</td>\n",
+              "      <td>14</td>\n",
+              "      <td>sci.space</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                                                Text  Label   \n",
+              "0   WHAT car is this!?\\nNntp-Posting-Host: rac3.w...      7  \\\n",
+              "1   SI Clock Poll - Final Call\\nSummary: Final ca...      4   \n",
+              "2   PB questions...\\nOrganization: Purdue Univers...      4   \n",
+              "3   Re: Weitek P9000 ?\\nOrganization: Harris Comp...      1   \n",
+              "4   Re: Shuttle Launch Question\\nOrganization: Sm...     14   \n",
+              "\n",
+              "              Class Name  \n",
+              "0              rec.autos  \n",
+              "1  comp.sys.mac.hardware  \n",
+              "2  comp.sys.mac.hardware  \n",
+              "3          comp.graphics  \n",
+              "4              sci.space  "
+            ]
+          },
+          "execution_count": 9,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Apply preprocessing function to training and test datasets\n",
+        "df_train = preprocess_newsgroup_data(newsgroups_train)\n",
+        "df_test = preprocess_newsgroup_data(newsgroups_test)\n",
+        "\n",
+        "df_train.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ogEGbg5XDv-T"
+      },
+      "source": [
+        "Next, you will sample some of the data by taking 100 data points in the training dataset, and dropping a few of the categories to run through this tutorial. Choose the science categories to compare."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "C2N7xXhJohLR"
+      },
+      "outputs": [],
+      "source": [
+        "def sample_data(df, num_samples, classes_to_keep):\n",
+        "  df = df.groupby('Label', as_index = False).apply(lambda x: x.sample(num_samples)).reset_index(drop=True)\n",
+        "\n",
+        "  df = df[df['Class Name'].str.contains(classes_to_keep)]\n",
+        "\n",
+        "  # Reset the encoding of the labels after sampling and dropping certain categories\n",
+        "  df['Class Name'] = df['Class Name'].astype('category')\n",
+        "  df['Encoded Label'] = df['Class Name'].cat.codes\n",
+        "\n",
+        "  return df"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "jS2g_ZGupBUb"
+      },
+      "outputs": [],
+      "source": [
+        "TRAIN_NUM_SAMPLES = 100\n",
+        "TEST_NUM_SAMPLES = 25\n",
+        "CLASSES_TO_KEEP = 'sci' # Class name should contain 'sci' in it to keep science categories\n",
+        "df_train = sample_data(df_train, TRAIN_NUM_SAMPLES, CLASSES_TO_KEEP)\n",
+        "df_test = sample_data(df_test, TEST_NUM_SAMPLES, CLASSES_TO_KEEP)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "j04TMPY8rV5q",
+        "outputId": "cf481eda-797e-42fb-8138-ef6925a6a4ba"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "Class Name\n",
+              "sci.crypt          100\n",
+              "sci.electronics    100\n",
+              "sci.med            100\n",
+              "sci.space          100\n",
+              "Name: count, dtype: int64"
+            ]
+          },
+          "execution_count": 12,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_train.value_counts('Class Name')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "qMsnfkVDsJlU",
+        "outputId": "8181fed1-c09d-490a-f774-e49402c62522"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "Class Name\n",
+              "sci.crypt          25\n",
+              "sci.electronics    25\n",
+              "sci.med            25\n",
+              "sci.space          25\n",
+              "Name: count, dtype: int64"
+            ]
+          },
+          "execution_count": 13,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_test.value_counts('Class Name')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Kr-WlKzXjYWn"
+      },
+      "source": [
+        "## Create the embeddings\n",
+        "\n",
+        "Next, you need to compute the text embeddings. You will be using the PaLM API to [generate embeddings](https://developers.generativeai.google/api/python/google/generativeai/generate_embeddings). For a basic understanding of how the generation of embeddings works, it's recommended to go through the [embeddings quickstart notebook](../tutorials/embeddings_quickstart.ipynb) first.\n",
+        "\n",
+        "**NOTE**: Embeddings are computed one at a time, large sample sizes can take a long time!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "MTBGKkPQsotz"
+      },
+      "outputs": [],
+      "source": [
+        "from tqdm.auto import tqdm\n",
+        "tqdm.pandas()\n",
+        "\n",
+        "from google.api_core import retry\n",
+        "\n",
+        "def make_embed_text_fn(model):\n",
+        "\n",
+        "  @retry.Retry(timeout=300.0)\n",
+        "  def embed_fn(text: str) -> list[float]:\n",
+        "    return palm.generate_embeddings(model=model, text=text)['embedding']\n",
+        "\n",
+        "  return embed_fn\n",
+        "\n",
+        "def create_embeddings(model, df):\n",
+        "  df['Embeddings'] = df['Text'].progress_apply(make_embed_text_fn(model))\n",
+        "  return df"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "AH0yrHUHtHtw",
+        "outputId": "86e7b0c2-52ce-4805-9ca3-00e035029869",
+        "colab": {
+          "referenced_widgets": [
+            "4f4af8e96e52446182909cf12686a4b1",
+            "39ce50446406413ab8b67638ed0b8216"
+          ]
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "4f4af8e96e52446182909cf12686a4b1",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "  0%|          | 0/400 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "39ce50446406413ab8b67638ed0b8216",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "  0%|          | 0/100 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "df_train = create_embeddings(model, df_train)\n",
+        "df_test = create_embeddings(model, df_test)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6G5TvLlmRjHc",
+        "outputId": "ae14f640-38e0-4751-a4cf-76bbe305ca00"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>Text</th>\n",
+              "      <th>Label</th>\n",
+              "      <th>Class Name</th>\n",
+              "      <th>Encoded Label</th>\n",
+              "      <th>Embeddings</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>1100</th>\n",
+              "      <td>Re: Why the clipper algorithm is secret\\nOrga...</td>\n",
+              "      <td>11</td>\n",
+              "      <td>sci.crypt</td>\n",
+              "      <td>0</td>\n",
+              "      <td>[0.006307477, -0.03455442, 0.0020199143, 0.029...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1101</th>\n",
+              "      <td>Re: Would \"clipper\" make a good cover for oth...</td>\n",
+              "      <td>11</td>\n",
+              "      <td>sci.crypt</td>\n",
+              "      <td>0</td>\n",
+              "      <td>[-0.008315406, -0.0025919464, 0.010398931, 0.0...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1102</th>\n",
+              "      <td>Re: Fifth Amendment and Passwords\\nNntp-Posti...</td>\n",
+              "      <td>11</td>\n",
+              "      <td>sci.crypt</td>\n",
+              "      <td>0</td>\n",
+              "      <td>[-0.02041764, -0.014947017, 0.0077807712, 0.04...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1103</th>\n",
+              "      <td>Re: Another data hiding scheme... \\nDistribut...</td>\n",
+              "      <td>11</td>\n",
+              "      <td>sci.crypt</td>\n",
+              "      <td>0</td>\n",
+              "      <td>[0.009049227, -0.06057404, 0.017259106, 0.0024...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1104</th>\n",
+              "      <td>Re: Once tapped, your code is no good any mor...</td>\n",
+              "      <td>11</td>\n",
+              "      <td>sci.crypt</td>\n",
+              "      <td>0</td>\n",
+              "      <td>[-0.0005989545, -0.0020057857, -0.0025177177, ...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                                                   Text  Label Class Name   \n",
+              "1100   Re: Why the clipper algorithm is secret\\nOrga...     11  sci.crypt  \\\n",
+              "1101   Re: Would \"clipper\" make a good cover for oth...     11  sci.crypt   \n",
+              "1102   Re: Fifth Amendment and Passwords\\nNntp-Posti...     11  sci.crypt   \n",
+              "1103   Re: Another data hiding scheme... \\nDistribut...     11  sci.crypt   \n",
+              "1104   Re: Once tapped, your code is no good any mor...     11  sci.crypt   \n",
+              "\n",
+              "      Encoded Label                                         Embeddings  \n",
+              "1100              0  [0.006307477, -0.03455442, 0.0020199143, 0.029...  \n",
+              "1101              0  [-0.008315406, -0.0025919464, 0.010398931, 0.0...  \n",
+              "1102              0  [-0.02041764, -0.014947017, 0.0077807712, 0.04...  \n",
+              "1103              0  [0.009049227, -0.06057404, 0.017259106, 0.0024...  \n",
+              "1104              0  [-0.0005989545, -0.0020057857, -0.0025177177, ...  "
+            ]
+          },
+          "execution_count": 16,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df_train.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "QPYEYkIsWt_5"
+      },
+      "source": [
+        "## Build a simple classification model\n",
+        "Here you will define a simple model with one hidden layer and a single class probability output. The prediction will correspond to the probability of a piece of text being a particular class of news. When you build your model, Keras will automatically shuffle the data points."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3oLGi4w5JsQR"
+      },
+      "outputs": [],
+      "source": [
+        "def build_classification_model(input_size: int, num_classes: int) -> keras.Model:\n",
+        "  inputs = x = keras.Input(input_size)\n",
+        "  x = layers.Dense(input_size, activation='relu')(x)\n",
+        "  x = layers.Dense(num_classes, activation='sigmoid')(x)\n",
+        "  return keras.Model(inputs=[inputs], outputs=x)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "kORA1Akl5GsG",
+        "outputId": "e0352a1a-f938-4dc3-8414-4fed97ed3e45"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Model: \"model\"\n",
+            "_________________________________________________________________\n",
+            " Layer (type)                Output Shape              Param #   \n",
+            "=================================================================\n",
+            " input_1 (InputLayer)        [(None, 768)]             0         \n",
+            "                                                                 \n",
+            " dense (Dense)               (None, 768)               590592    \n",
+            "                                                                 \n",
+            " dense_1 (Dense)             (None, 4)                 3076      \n",
+            "                                                                 \n",
+            "=================================================================\n",
+            "Total params: 593668 (2.26 MB)\n",
+            "Trainable params: 593668 (2.26 MB)\n",
+            "Non-trainable params: 0 (0.00 Byte)\n",
+            "_________________________________________________________________\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "2023-05-19 10:48:14.210811: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:995] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero. See more at https://github.com/torvalds/linux/blob/v6.0/Documentation/ABI/testing/sysfs-bus-pci#L344-L355\n",
+            "2023-05-19 10:48:14.211994: W tensorflow/core/common_runtime/gpu/gpu_device.cc:1960] Cannot dlopen some GPU libraries. Please make sure the missing libraries mentioned above are installed properly if you would like to use GPU. Follow the guide at https://www.tensorflow.org/install/gpu for how to download and setup the required libraries for your platform.\n",
+            "Skipping registering GPU devices...\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Derive the embedding size from the first training element.\n",
+        "embedding_size = len(df_train['Embeddings'].iloc[0])\n",
+        "\n",
+        "# Give your model a different name, as you have already used the variable name 'model'\n",
+        "classifier = build_classification_model(embedding_size, len(df_train['Class Name'].unique()))\n",
+        "classifier.summary()\n",
+        "\n",
+        "classifier.compile(loss = keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
+        "                   optimizer = keras.optimizers.Adam(learning_rate=0.001),\n",
+        "                   metrics=['accuracy'])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "iPYYKnqFvt9x",
+        "outputId": "9c2b76af-3db9-4acf-c57e-08041c658e22"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "768"
+            ]
+          },
+          "execution_count": 19,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "embedding_size"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kbpTGGiMXDxl"
+      },
+      "source": [
+        "## Train the model to classify newsgroups\n",
+        "\n",
+        "Finally, you can train a simple model. Use a small number of epochs to avoid overfitting. The first epoch takes much longer than the rest, because the embeddings need to be computed only once."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bGgvMZGfJ1A4",
+        "outputId": "55d26e4b-0f38-461a-b1a6-be1220ee40ab"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Epoch 1/20\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/usr/local/google/home/markdaoust/venv3/lib/python3.10/site-packages/keras/src/backend.py:5714: UserWarning: \"`sparse_categorical_crossentropy` received `from_logits=True`, but the `output` argument was produced by a Softmax activation and thus does not represent logits. Was this intended?\n",
+            "  output, from_logits = _get_logits(\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "13/13 [==============================] - 1s 21ms/step - loss: 1.2284 - accuracy: 0.6025 - val_loss: 1.0366 - val_accuracy: 0.9100\n",
+            "Epoch 2/20\n",
+            "13/13 [==============================] - 0s 8ms/step - loss: 0.8011 - accuracy: 0.9450 - val_loss: 0.6998 - val_accuracy: 0.8500\n",
+            "Epoch 3/20\n",
+            "13/13 [==============================] - 0s 7ms/step - loss: 0.4617 - accuracy: 0.9700 - val_loss: 0.4686 - val_accuracy: 0.8900\n",
+            "Epoch 4/20\n",
+            "13/13 [==============================] - 0s 7ms/step - loss: 0.2774 - accuracy: 0.9725 - val_loss: 0.3689 - val_accuracy: 0.8700\n",
+            "Epoch 5/20\n",
+            "13/13 [==============================] - 0s 7ms/step - loss: 0.1821 - accuracy: 0.9775 - val_loss: 0.3158 - val_accuracy: 0.8800\n",
+            "Epoch 6/20\n",
+            "13/13 [==============================] - 0s 8ms/step - loss: 0.1335 - accuracy: 0.9800 - val_loss: 0.2899 - val_accuracy: 0.8800\n",
+            "Epoch 7/20\n",
+            "13/13 [==============================] - 0s 7ms/step - loss: 0.1080 - accuracy: 0.9775 - val_loss: 0.2952 - val_accuracy: 0.8600\n",
+            "Epoch 8/20\n",
+            "13/13 [==============================] - 0s 7ms/step - loss: 0.0852 - accuracy: 0.9825 - val_loss: 0.2593 - val_accuracy: 0.8900\n",
+            "Epoch 9/20\n",
+            "13/13 [==============================] - 0s 7ms/step - loss: 0.0708 - accuracy: 0.9850 - val_loss: 0.2523 - val_accuracy: 0.9000\n",
+            "Epoch 10/20\n",
+            "13/13 [==============================] - 0s 7ms/step - loss: 0.0579 - accuracy: 0.9900 - val_loss: 0.2678 - val_accuracy: 0.9000\n",
+            "Epoch 11/20\n",
+            "13/13 [==============================] - 0s 7ms/step - loss: 0.0504 - accuracy: 0.9950 - val_loss: 0.2313 - val_accuracy: 0.9200\n",
+            "Epoch 12/20\n",
+            "13/13 [==============================] - 0s 7ms/step - loss: 0.0429 - accuracy: 0.9975 - val_loss: 0.2417 - val_accuracy: 0.9100\n",
+            "Epoch 13/20\n",
+            "13/13 [==============================] - 0s 6ms/step - loss: 0.0379 - accuracy: 0.9975 - val_loss: 0.2340 - val_accuracy: 0.9100\n",
+            "Epoch 14/20\n",
+            "13/13 [==============================] - 0s 7ms/step - loss: 0.0307 - accuracy: 0.9975 - val_loss: 0.2364 - val_accuracy: 0.9200\n",
+            "Epoch 15/20\n",
+            "13/13 [==============================] - 0s 8ms/step - loss: 0.0262 - accuracy: 1.0000 - val_loss: 0.2261 - val_accuracy: 0.9100\n",
+            "Epoch 16/20\n",
+            "13/13 [==============================] - 0s 6ms/step - loss: 0.0224 - accuracy: 1.0000 - val_loss: 0.2313 - val_accuracy: 0.9200\n",
+            "Epoch 17/20\n",
+            "13/13 [==============================] - 0s 6ms/step - loss: 0.0207 - accuracy: 1.0000 - val_loss: 0.2169 - val_accuracy: 0.9200\n",
+            "Epoch 18/20\n",
+            "13/13 [==============================] - 0s 6ms/step - loss: 0.0172 - accuracy: 1.0000 - val_loss: 0.2245 - val_accuracy: 0.9200\n"
+          ]
+        }
+      ],
+      "source": [
+        "NUM_EPOCHS = 20\n",
+        "BATCH_SIZE = 32\n",
+        "\n",
+        "# Split the x and y components of the train and validation subsets.\n",
+        "y_train = df_train['Encoded Label']\n",
+        "x_train = np.stack(df_train['Embeddings'])\n",
+        "y_val = df_test['Encoded Label']\n",
+        "x_val = np.stack(df_test['Embeddings'])\n",
+        "\n",
+        "# Train the model for the desired number of epochs.\n",
+        "callback = keras.callbacks.EarlyStopping(monitor='accuracy', patience=3)\n",
+        "\n",
+        "history = classifier.fit(x=x_train,\n",
+        "                         y=y_train,\n",
+        "                         validation_data=(x_val, y_val),\n",
+        "                         callbacks=[callback],\n",
+        "                         batch_size=BATCH_SIZE,\n",
+        "                         epochs=NUM_EPOCHS,)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xGBaDHZUPdJO"
+      },
+      "source": [
+        "## Evaluate model performance\n",
+        "\n",
+        "Use Keras `Model.evaluate` to get the loss and accuracy on the test dataset."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "d2kOeiqqQIB8",
+        "outputId": "bd461260-b664-4835-ed0c-19567df2c421"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "4/4 [==============================] - 0s 4ms/step - loss: 0.2245 - accuracy: 0.9200\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "{'loss': 0.22447504103183746, 'accuracy': 0.9200000166893005}"
+            ]
+          },
+          "execution_count": 21,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "classifier.evaluate(x=x_val, y=y_val, return_dict=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "UyxMhiLYQXAN"
+      },
+      "source": [
+        "One way to evaluate your model performance is to visualize the classifier performance. Use `plot_history` to see the loss and accuracy trends over the epochs."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "MaDO9hwbEOW3",
+        "outputId": "8ed79013-8e5a-4d5b-8cd9-527ba5c4f07d"
+      },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAABlcAAAK9CAYAAAC5PTriAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAD1hklEQVR4nOzdeVxU9f7H8fcs7DuCCIqiuEKmaWqalZZFWla2mS2W3eq22L3l7XazLMtu+bst3rpl2WZmaWplq13L7JaVW2qaa7mguAAuIPs+8/vjwCCJCAicGXg9H495MHPmnDOfAZtg3vP9fCxOp9MpAAAAAAAAAAAA1IrV7AIAAAAAAAAAAAA8CeEKAAAAAAAAAABAHRCuAAAAAAAAAAAA1AHhCgAAAAAAAAAAQB0QrgAAAAAAAAAAANQB4QoAAAAAAAAAAEAdEK4AAAAAAAAAAADUAeEKAAAAAAAAAABAHRCuAAAAAAAAAAAA1AHhCgAAAAAAAAAAQB0QrgAAam3WrFmyWCxas2aN2aUAAAAAQIN65ZVXZLFYNGDAALNLAQB4AMIVAAAAAAAAtHhz5sxRXFycVq9erR07dphdDgDAzRGuAAAAAAAAoEVLTk7W8uXLNW3aNEVGRmrOnDlml1StvLw8s0sAAJQjXAEANKhffvlFw4cPV3BwsAIDA3XBBRdo5cqVVfYpKSnRE088oS5dusjX11etWrXS4MGDtWTJEtc+aWlpGjdunNq1aycfHx9FR0fr8ssv1+7du5v4GQEAAABo7ubMmaOwsDBdcskluvrqq6sNV44ePar7779fcXFx8vHxUbt27TR27FgdPnzYtU9hYaEef/xxde3aVb6+voqOjtaVV16pnTt3SpK+++47WSwWfffdd1XOvXv3blksFs2aNcu17ZZbblFgYKB27typESNGKCgoSDfccIMk6YcfftA111yj9u3by8fHR7Gxsbr//vtVUFBwXN3btm3Ttddeq8jISPn5+albt2565JFHJEn/+9//ZLFY9PHHHx933Ny5c2WxWLRixYo6fz8BoCWwm10AAKD52Lx5s8455xwFBwfrwQcflJeXl1577TUNGTJE33//vat38eOPP66pU6fqtttuU//+/ZWdna01a9Zo3bp1uvDCCyVJV111lTZv3qx7771XcXFxOnjwoJYsWaKUlBTFxcWZ+CwBAAAANDdz5szRlVdeKW9vb40ZM0avvvqqfv75Z/Xr10+SlJubq3POOUdbt27Vrbfeqj59+ujw4cP67LPPtG/fPkVERKisrEyXXnqpli5dquuuu05//etflZOToyVLlmjTpk2Kj4+vc12lpaVKSkrS4MGD9dxzz8nf31+S9MEHHyg/P1933XWXWrVqpdWrV+ull17Svn379MEHH7iO//XXX3XOOefIy8tLd9xxh+Li4rRz5059/vnneuqppzRkyBDFxsZqzpw5GjVq1HHfk/j4eA0cOPAUvrMA0HwRrgAAGsykSZNUUlKiH3/8UZ06dZIkjR07Vt26ddODDz6o77//XpK0aNEijRgxQq+//nq15zl69KiWL1+uZ599Vg888IBr+8SJExv/SQAAAABoUdauXatt27bppZdekiQNHjxY7dq105w5c1zhyrPPPqtNmzZp4cKFVUKISZMmyel0SpJmz56tpUuXatq0abr//vtd+zz00EOufeqqqKhI11xzjaZOnVpl+7/+9S/5+fm5bt9xxx3q3LmzHn74YaWkpKh9+/aSpHvvvVdOp1Pr1q1zbZOk//u//5MkWSwW3XjjjZo2bZqysrIUEhIiSTp06JC+/vpr1woXAMDxaAsGAGgQZWVl+vrrr3XFFVe4ghVJio6O1vXXX68ff/xR2dnZkqTQ0FBt3rxZ27dvr/Zcfn5+8vb21nfffafMzMwmqR8AAABAyzRnzhxFRUVp6NChkozAYfTo0Zo3b57KysokSR999JF69ep13OqOiv0r9omIiNC99957wn3q46677jpu27HBSl5eng4fPqxBgwbJ6XTql19+kWQEJMuWLdOtt95aJVj5Yz1jx45VUVGRPvzwQ9e2+fPnq7S0VDfeeGO96waA5o5wBQDQIA4dOqT8/Hx169btuPt69Oghh8OhvXv3SpKmTJmio0ePqmvXrurZs6f+/ve/69dff3Xt7+Pjo3/961/673//q6ioKJ177rl65plnlJaW1mTPBwAAAEDzV1ZWpnnz5mno0KFKTk7Wjh07tGPHDg0YMEDp6elaunSpJGnnzp067bTTajzXzp071a1bN9ntDdcoxm63q127dsdtT0lJ0S233KLw8HAFBgYqMjJS5513niQpKytLkrRr1y5JOmnd3bt3V79+/arMmZkzZ47OOussde7cuaGeCgA0O4QrAIAmd+6552rnzp2aOXOmTjvtNL355pvq06eP3nzzTdc+9913n37//XdNnTpVvr6+evTRR9WjRw/Xp7AAAAAA4FR9++23Sk1N1bx589SlSxfX5dprr5Wkagfbn4oTrWCpWCHzRz4+PrJarcfte+GFF2rRokX6xz/+oU8++URLlizRrFmzJEkOh6POdY0dO1bff/+99u3bp507d2rlypWsWgGAk2DmCgCgQURGRsrf31+//fbbcfdt27ZNVqtVsbGxrm3h4eEaN26cxo0bp9zcXJ177rl6/PHHddttt7n2iY+P19/+9jf97W9/0/bt29W7d289//zzeu+995rkOQEAAABo3ubMmaPWrVtr+vTpx923cOFCffzxx5oxY4bi4+O1adOmGs8VHx+vVatWqaSkRF5eXtXuExYWJsmYM3msPXv21LrmjRs36vfff9c777yjsWPHurYvWbKkyn4V7ZpPVrckXXfddZowYYLef/99FRQUyMvLS6NHj651TQDQErFyBQDQIGw2my666CJ9+umn2r17t2t7enq65s6dq8GDBys4OFiSdOTIkSrHBgYGqnPnzioqKpIk5efnq7CwsMo+8fHxCgoKcu0DAAAAAKeioKBACxcu1KWXXqqrr776uMv48eOVk5Ojzz77TFdddZU2bNigjz/++LjzVAyrv+qqq3T48GG9/PLLJ9ynQ4cOstlsWrZsWZX7X3nllVrXbbPZqpyz4vqLL75YZb/IyEide+65mjlzplJSUqqtp0JERISGDx+u9957T3PmzNHFF1+siIiIWtcEAC0RK1cAAHU2c+ZMLV68+Ljtjz/+uJYsWaLBgwfr7rvvlt1u12uvvaaioiI988wzrv0SEhI0ZMgQ9e3bV+Hh4VqzZo0+/PBDjR8/XpL0+++/64ILLtC1116rhIQE2e12ffzxx0pPT9d1113XZM8TAAAAQPP12WefKScnR5dddlm195911lmKjIzUnDlzNHfuXH344Ye65pprdOutt6pv377KyMjQZ599phkzZqhXr14aO3asZs+erQkTJmj16tU655xzlJeXp2+++UZ33323Lr/8coWEhOiaa67RSy+9JIvFovj4eH3xxRc6ePBgrevu3r274uPj9cADD2j//v0KDg7WRx99pMzMzOP2/c9//qPBgwerT58+uuOOO9SxY0ft3r1bixYt0vr166vsO3bsWF199dWSpCeffLL230gAaKEIVwAAdfbqq69Wu/2WW27RDz/8oIkTJ2rq1KlyOBwaMGCA3nvvPQ0YMMC131/+8hd99tln+vrrr1VUVKQOHTron//8p/7+979LkmJjYzVmzBgtXbpU7777rux2u7p3764FCxboqquuapLnCAAAAKB5mzNnjnx9fXXhhRdWe7/VatUll1yiOXPmqKioSD/88IMmT56sjz/+WO+8845at26tCy64wDVw3maz6csvv9RTTz2luXPn6qOPPlKrVq00ePBg9ezZ03Xel156SSUlJZoxY4Z8fHx07bXX6tlnnz3p4PkKXl5e+vzzz/WXv/zFNaNy1KhRGj9+vHr16lVl3169emnlypV69NFH9eqrr6qwsFAdOnRwzZQ51siRIxUWFiaHw3HCwAkAUMni/OM6QAAAAAAAAAAtSmlpqWJiYjRy5Ei99dZbZpcDAG6PmSsAAAAAAABAC/fJJ5/o0KFDGjt2rNmlAIBHYOUKAAAAAAAA0EKtWrVKv/76q5588klFRERo3bp1ZpcEAB6BlSsAAAAAAABAC/Xqq6/qrrvuUuvWrTV79myzywEAj8HKFQAAAAAAAAAAgDpg5QoAAAAAAAAAAEAdEK4AAAAAAAAAAADUgd3sApqaw+HQgQMHFBQUJIvFYnY5AAAAQKNzOp3KyclRTEyMrFY+X4WT4+8mAAAAtCT1+ZupxYUrBw4cUGxsrNllAAAAAE1u7969ateundllwAPwdxMAAABaorr8zdTiwpWgoCBJxjcpODjY5GoAAACAxpedna3Y2FjX78LAyfB3EwAAAFqS+vzN1OLClYol7cHBwfyRAAAAgBaF9k6oLf5uAgAAQEtUl7+ZaLgMAAAAAAAAAABQB4QrAAAAAAAAAAAAdUC4AgAAAAAAAAAAUActbuYKAAAAJKfTqdLSUpWVlZldChqAzWaT3W5npgqaVFlZmUpKSswuAw2E1xEAAIC6IVwBAABoYYqLi5Wamqr8/HyzS0ED8vf3V3R0tLy9vc0uBS1Abm6u9u3bJ6fTaXYpaEC8jgAAANQe4QoAAEAL4nA4lJycLJvNppiYGHl7e/MpZQ/ndDpVXFysQ4cOKTk5WV26dJHVSvdfNJ6ysjLt27dP/v7+ioyM5DWkGeB1BAAAoO4IVwAAAFqQ4uJiORwOxcbGyt/f3+xy0ED8/Pzk5eWlPXv2qLi4WL6+vmaXhGaspKRETqdTkZGR8vPzM7scNBBeRwAAAOqGj6IAAAC0QHwiufnhZ4qmxoqV5ofXEQAAgNrjNycAAAAAAAAAAIA6IFwBAAAAAAAAAACoA8IVAAAAtEhxcXF64YUXzC4DgAfjdQQAAKDlIlwBAACAW7NYLDVeHn/88Xqd9+eff9Ydd9zRsMUCcEu8jgAAAKCh2c0uAAAAAKhJamqq6/r8+fP12GOP6bfffnNtCwwMdF13Op0qKyuT3X7yX3MjIyMbtlAAbovXEQAAADQ0Vq4AAAC0cE6nU/nFpU1+cTqdtaqvTZs2rktISIgsFovr9rZt2xQUFKT//ve/6tu3r3x8fPTjjz9q586duvzyyxUVFaXAwED169dP33zzTZXz/rGdj8Vi0ZtvvqlRo0bJ399fXbp00WeffdaQ32qgWTLrNYTXEQAAAJiJlSsAAAAtXEFJmRIe+6rJH3fLlCT5ezfMr6MPPfSQnnvuOXXq1ElhYWHau3evRowYoaeeeko+Pj6aPXu2Ro4cqd9++03t27c/4XmeeOIJPfPMM3r22Wf10ksv6YYbbtCePXsUHh7eIHUCzZFZryESryMAAAAwDytXAAAA4PGmTJmiCy+8UPHx8QoPD1evXr305z//Waeddpq6dOmiJ598UvHx8Sf9BPktt9yiMWPGqHPnznr66aeVm5ur1atXN9GzAGAmXkcAAABQF6xcAQAAaOH8vGzaMiXJlMdtKGeeeWaV27m5uXr88ce1aNEipaamqrS0VAUFBUpJSanxPKeffrrrekBAgIKDg3Xw4MEGqxNojsx6Dal47IbC6wgAAADqgnAFAACghbNYLA3WVscsAQEBVW4/8MADWrJkiZ577jl17txZfn5+uvrqq1VcXFzjeby8vKrctlgscjgcDV4v0Jw0h9cQidcRAAAA1I3n/wYMAAAA/MFPP/2kW265RaNGjZJkfAJ99+7d5hYFwKPwOgIAAICaMHMFAAAAzU6XLl20cOFCrV+/Xhs2bND111/PJ8cB1AmvIwAAAKgJ4QoAAACanWnTpiksLEyDBg3SyJEjlZSUpD59+phdFgAPwusIAAAAamJxOp1Os4toStnZ2QoJCVFWVpaCg4PNLgcAAKBJFRYWKjk5WR07dpSvr6/Z5aAB1fSz5Xdg97Vs2TI9++yzWrt2rVJTU/Xxxx/riiuuqPGY7777ThMmTNDmzZsVGxurSZMm6ZZbbqmyz/Tp0/Xss88qLS1NvXr10ksvvaT+/fvXuq6a/s3wOtJ88bMFAAAtVX3+ZmLlCgAAAACYJC8vT7169dL06dNrtX9ycrIuueQSDR06VOvXr9d9992n2267TV999ZVrn/nz52vChAmaPHmy1q1bp169eikpKUkHDx5srKcBAAAAtDgMtG9i29Ky9eu+LJ3fvbUiAn3MLgcAAACAiYYPH67hw4fXev8ZM2aoY8eOev755yVJPXr00I8//qh///vfSkpKkmS0s7r99ts1btw41zGLFi3SzJkz9dBDDzX8kwAAADCB0+nU0fwSHcot0uGcImUXlphdEhpAn/Zhah3sGStoCVea2AMfbNCm/dmacWMfXXxatNnlAAAAAPAgK1as0LBhw6psS0pK0n333SdJKi4u1tq1azVx4kTX/VarVcOGDdOKFStOeN6ioiIVFRW5bmdnZzds4QAAALWUX1yqQzlFlZfcompvH84tUklZi5p40SLMvOVMnU+4guokRAdr0/5sbTmQTbgCAAAAoE7S0tIUFRVVZVtUVJSys7NVUFCgzMxMlZWVVbvPtm3bTnjeqVOn6oknnmiUmgEAAIpLHTqS94eQ5A9BScW2vOKyOp07xM9LkUE+CvHzkqWR6kfTCfHzMruEWiNcaWKJMSGS9mnzAT4JBgAAAMA9TJw4URMmTHDdzs7OVmxsrIkVAQAAd+dwOHW0oOSYoKTwhCtOMvPr1rLL18uq1kG+igzyUWSgj/G1/BIReOx1b/nYbY30DIGaEa40scSYYEkiXAEAAABQZ23atFF6enqVbenp6QoODpafn59sNptsNlu1+7Rp0+aE5/Xx8ZGPDzMhAQDNk8PhVEZ+seuN/mNXSVQEADmFpWaX6THKHE5l5BXrcG6RSh21b8tlt1qqBCMVoUlEoLciK4KU8kuAt00WC+tQ4N4IV5pYj+hgWSxSWnahjuQWqRVD7QEAAADU0sCBA/Xll19W2bZkyRINHDhQkuTt7a2+fftq6dKluuKKKyRJDodDS5cu1fjx45u6XAAAGo3T6VRuUelJ53IcyinSkbxildUhBEDdhAd4/yEoOTZAqQxNQv28ZLUSmKD5IFxpYgE+dnVsFaBdh/O0+UC2zu0aaXZJAAAAAEySm5urHTt2uG4nJydr/fr1Cg8PV/v27TVx4kTt379fs2fPliTdeeedevnll/Xggw/q1ltv1bfffqsFCxZo0aJFrnNMmDBBN998s84880z1799fL7zwgvLy8jRu3Lgmf34AANRVYUlZtStLjr1dcX9hiaNO524V4H3cqomKS7CvlxjYUTtWi0Xh/sb3slWgt7xsVrNLAkxBuGKChJhgwhUAAAAAWrNmjYYOHeq6XTH35Oabb9asWbOUmpqqlJQU1/0dO3bUokWLdP/99+vFF19Uu3bt9OabbyopKcm1z+jRo3Xo0CE99thjSktLU+/evbV48eLjhtwDANCUnE6n0rOL9Ht6jg4et8KkclZHdh3bcwX52BVRTVjyx9vhAYQAABoW4YoJEmKC9cWvqdqSytwVAACApjJkyBD17t1bL7zwgiQpLi5O9913n+67774THmOxWPTxxx+72ivVV0OdB83PkCFD5HSeuE3JrFmzqj3ml19+qfG848ePpw1YA+M1BABqr6TMoV2H8rQlNUtbDmRra2qOtqRmKyOvuFbHe9usRoupGkKT1uWDzf28GWYOwByEKyZIjAmRJG0+kGVyJQAAAJ5h5MiRKikp0eLFi4+774cfftC5556rDRs26PTTT6/1OX/++WcFBAQ0ZJl6/PHH9cknn2j9+vVVtqempiosLKxBHwtA7fEaAgCNJ6ewRNvScrTlQLZxSc3Wb+k5Ki49vmWXzWpRx4gARYf4VrvCpHX5jI5gPzvDzAG4PcIVEyTGBEuSkg/nKa+oVAE+/BgAAABq8qc//UlXXXWV9u3bp3bt2lW57+2339aZZ55ZpzdFJSkysunas7Zp06bJHgvA8XgNAYBT53Q6lZpV6ApQKr6mZORXu3+At009ooOVEBOshPKvXaOC5OvFShMAzYOpjQaXLVumkSNHKiYmRhaLRZ988kmN+y9cuFAXXnihIiMjFRwcrIEDB+qrr75qmmIbUESgj6KCfeR0StvSaA0GAABM5nRKxXlNf6mhFdIfXXrppYqMjDyuRVJubq4++OADXXHFFRozZozatm0rf39/9ezZU++//36N54yLi3O195Gk7du369xzz5Wvr68SEhK0ZMmS4475xz/+oa5du8rf31+dOnXSo48+qpKSEklG+6YnnnhCGzZskMVikcVicdX7x991N27cqPPPP19+fn5q1aqV7rjjDuXm5rruv+WWW3TFFVfoueeeU3R0tFq1aqV77rnH9ViAWzHrNaQOryO8hvAaAqBuSsoc2pqarY/W7tOTX2zRmNdX6ownl2jQ/32r22av0bQlv2vx5jRXsBId4qsLurfWved31qs39NH3fx+ijY8n6cO7BmnK5afpuv7tdXq7UIIVAM2KqUsm8vLy1KtXL91666268sorT7r/smXLdOGFF+rpp59WaGio3n77bY0cOVKrVq3SGWec0QQVN5zEmBClZx/U5gPZ6tsh3OxyAABAS1aSLz0d0/SP+/ABybt2LXXsdrvGjh2rWbNm6ZFHHnG1ifjggw9UVlamG2+8UR988IH+8Y9/KDg4WIsWLdJNN92k+Ph49e/f/6TndzgcuvLKKxUVFaVVq1YpKyur2jkKQUFBmjVrlmJiYrRx40bdfvvtCgoK0oMPPqjRo0dr06ZNWrx4sb755htJUkhIyHHnyMvLU1JSkgYOHKiff/5ZBw8e1G233abx48dXeeP3f//7n6Kjo/W///1PO3bs0OjRo9W7d2/dfvvttfqeAU3GrNcQqdavI7yG8BoC4MSyCkq0tXwlytZUYzXK9vRcFZdV39arS+tA10qUHtHGJTzA24TKAcBcpoYrw4cP1/Dhw2u9/7GfCpKkp59+Wp9++qk+//xzDwxXgvXttoPacoCVKwAAALVx66236tlnn9X333+vIUOGSDLa+Vx11VXq0KGDHnjgAde+9957r7766istWLCgVm+MfvPNN9q2bZu++uorxcQYbxI//fTTx/2uOmnSJNf1uLg4PfDAA5o3b54efPBB+fn5KTAwUHa7vcYWPnPnzlVhYaFmz57tmtfw8ssva+TIkfrXv/6lqKgoSVJYWJhefvll2Ww2de/eXZdccomWLl3KG6NAPfEawmsI0NI5nU7tyyxwBSgVbb32ZRZUu3+Qj109Klp6lYcpnVsHsvoEAMp59LAPh8OhnJwchYefeOVHUVGRioqKXLezs90jzEiINuaubCZcAQAAZvPyNz79bcbj1kH37t01aNAgzZw5U0OGDNGOHTv0ww8/aMqUKSorK9PTTz+tBQsWaP/+/SouLlZRUZH8/Wv3GFu3blVsbKzrTVFJGjhw4HH7zZ8/X//5z3+0c+dO5ebmqrS0VMHBwXV6Hlu3blWvXr2qDMI+++yz5XA49Ntvv7neGE1MTJTNVvnmRXR0tDZu3FinxwKahFmvIRWPXUu8hvAaArQkxaUObT+YU2U+ytbUbGUXlla7f9tQvyrzURJjgtUuzI+h8gBQA48OV5577jnl5ubq2muvPeE+U6dO1RNPPNGEVdVOYoyxvPu3tByVlDnkZTN1/A0AAGjJLJZat+cy25/+9Cfde++9mj59ut5++23Fx8frvPPO07/+9S+9+OKLeuGFF9SzZ08FBATovvvuU3FxcYM99ooVK3TDDTfoiSeeUFJSkkJCQjRv3jw9//zzDfYYx/Ly8qpy22KxyOE4vj0HYDpeQ2qF1xAAjeVofnGVlShbDmRrx8FclTqOn0tlt1rUJSrItRIlITpYPaKDFOpPWy8AqCuPDVfmzp2rJ554Qp9++qlat259wv0mTpyoCRMmuG5nZ2crNja2KUqsUWy4n4J87copLNWOg7nqEV23TysBAAC0RNdee63++te/au7cuZo9e7buuusuWSwW/fTTT7r88st14403SjJWOP/+++9KSEio1Xl79OihvXv3KjU1VdHR0ZKklStXVtln+fLl6tChgx555BHXtj179lTZx9vbW2VlZSd9rFmzZikvL8/1yfOffvpJVqtV3bp1q1W9AOqH1xAAnszpdGpvRoG2pGaVByk52pqarf1Hq2/rFexrV4/oYCXGhKhHdJCrrZePnbZeANAQPDJcmTdvnm677TZ98MEHGjZsWI37+vj4yMfHp4kqqz2LxaKE6GCtSs7Q5gPZhCsAAAC1EBgYqNGjR2vixInKzs7WLbfcIknq0qWLPvzwQy1fvlxhYWGaNm2a0tPTa/3G6LBhw9S1a1fdfPPNevbZZ5WdnV3lDdCKx0hJSdG8efPUr18/LVq0SB9//HGVfeLi4pScnKz169erXbt2CgoKOu530RtuuEGTJ0/WzTffrMcff1yHDh3Svffeq5tuusnVzgdA4+A1BICnKCwp046Duce19copqr6tV2y4X/kqlMr5KG1DaesFAI3J43pRvf/++xo3bpzef/99XXLJJWaXc0oqWoNtPpBlciUAAACe409/+pMyMzOVlJTkmm8wadIk9enTR0lJSRoyZIjatGmjK664otbntFqt+vjjj1VQUKD+/fvrtttu01NPPVVln8suu0z333+/xo8fr969e2v58uV69NFHq+xz1VVX6eKLL9bQoUMVGRmp999//7jH8vf311dffaWMjAz169dPV199tS644AK9/PLLdf9mAKgzXkMAuJuMvGL9tOOw3li2S/fPX6+kfy9T4uSvdOlLP+rBj37VrOW7tXp3hnKKSuVtsyoxJljX9G2nySMTNP+Os7Rh8kX64cHz9dpNZ+q+YV11UWIbtQvzJ1gBgEZmcTqdxzdgbCK5ubnasWOHJOmMM87QtGnTNHToUIWHh6t9+/aaOHGi9u/fr9mzZ0syWoHdfPPNevHFF3XllVe6zuPn56eQkJBaPWZ2drZCQkKUlZVV58GBDe3Dtfv0wAcbNKBjuOb/+fhhhwAAAA2tsLBQycnJ6tixo3x9fc0uBw2opp+tO/0ODM9Q078ZXkeaL362QONyOJxKycg/bj5KWnZhtfuH+nsZq1Aq5qPEBCs+MpC5vQDQCOrzN5OpbcHWrFmjoUOHum5XzEa5+eabNWvWLKWmpiolJcV1/+uvv67S0lLdc889uueee1zbK/b3NIkxxg9pS2q2nE4nnygAAAAAAABoBgpLyvRbWo62pBrtvCraeuUVVz9XqUMr/ypBSo/oYEWH+PJeEQC4MVPDlSFDhqimhTN/DEy+++67xi2oiXVuHShvu1U5haXam1Gg9q38zS4JAAAAAAAAtVRQXKZDOUXak5FXZTXKzkO5clTzlpe33arubYLUo03lapTubYIU5OvV9MUDAE6JRw60by68bFZ1iwrSxv1Z2nwgi3AFAAAAAADAZCVlDh3JLdahnCIdyi3U4ZxiHcotMm5XXMpv555gwLwkhQd4V7b0Kv/aKSJAdtp6AUCzQLhissSY4PJwJVvDe0abXQ4AAAAAAECz43Q6dTS/5IQhybG3M/KK63RuH7tVbUP91OMPQUrrIB/aegFAM0a4YrKKuSubD2SZXAkAAGhJamrNCs/EzxRNjX9zzQ8/U3iivKLS6kOSnCIdzq3cfji3SCVltf83brNaFBHorcggH0UG+hhfg3wUUXH9mG2BPnZCFABogQhXTJZwzFB7AACAxublZfTzzs/Pl5+fn8nVoCHl5+dLqvwZA43FZrNJkoqLi3kdaWZ4HYE7cjqd2pdZ4Jplsv1gjg5mV4Ym+ScYEH8iof5eVYKRKteP2Rbm7y2rlcAEAHBihCsm694mWBaLlJ5tfIoiItDH7JIAAEAzZrPZFBoaqoMHD0qS/P39+aSlh3M6ncrPz9fBgwcVGhrqeuMbaCx2u13+/v46dOiQvLy8ZLUyO8DT8ToCd1FUWqbt6bmuIGVLara2pmYrp/DEc00kyc/LptbBPjWGJhGBPmoV6C0fO/++AQANg3DFZAE+dnWMCNCuQ3nafCBb53WNNLskAADQzLVp00aSXAELmofQ0FDXzxZoTBaLRdHR0UpOTtaePXvMLgcNiNcRNKXMvGJtTc2uEqTsOJirUsfxrbu8bBZ1aR2khJhgdW8TpJhQvyoBSoAPb28BAJoe//dxA4kxIeXhShbhCgAAaHQVb4y2bt1aJSUlZpeDBuDl5cUnzdGkvL291aVLFxUX123oM9wXryPmKHM4dSTPmAUS0UxXVTgcTu3NzDeClAOVYcqBrMJq9w/x83INhE+IDlaP6GB1bh0obzur5AAA7oVwxQ0kxgTr8w0HtPkAc1cAAEDTsdlsvJEGoN6sVqt8fX3NLgNwO06nU9mFpZWD1f84aP2Y2xl5RTp2oUaIn1f1c0ACfRRxzPbwAG/Z3HAeSGFJRVuvrGPaeuUot6j6tl7tw/1dAUpCjHGJCfGlZSkAwCMQrriBxPKh9lsJVwAAAAAAcEuFJWU6lFOkg9WEJIdzq4YnxaWOWp/XYpFsFotKHU5lFZQoq6BEOw7m1niM1SK1Cqw+hPnjcPYgH3ujhBUZecXlAYoRpGxNzdGOQ7kqq6atl7fNqq5tAo0VKdHBSogJUffoIAX7ejV4XQAANBXCFTeQEG2EK8lH8pRXVEqvUAAAAAAAmkBpmUNH8oprXGFyuPx2zglWX5xIkK/9pKtQWh+zCiWroOSkq10O5xbpSF6xHE657lNqzXX42K0nDl/+sCLG1+v4Fa0Oh1N7MvLLA5TKtl5p2dW39Qrz93K19DK+hqhTZIC8bLT1AgA0L7yL7wZaBfqoTbCv0rILtTU1W2fGhZtdEgAAAAAAzcKhnCJXILD9YE6V0CIjv1jO4xdanJC33arWJwgm/hhgVBdU1CTU31uh/t7qEhVU436lZQ5l5BUbK2hqEQgVlTq0L7NA+zILTlrDsYFQRKCP0rILtS01W3nFZdXuH9fKv0qQ0iM6WG2CaesFAGgZCFfcRGJMsNKyC7X5AOEKAAAAAAB1VeZwKvlwnitIqVhlcSinqMbjrBYpojxMMKvFVl3YbVa1DvZV6+CTzzyqaGVW09yXY1uZ5RSWKqewVLsO5VU5j4/dqu5tglwBSkJ0sLpHByuQzhsAgBaM/wu6icSYYC3ddlCbD2SZXQoAAAAAAG4tv7hU29JyXEPTtxzI1ra0bBWWHD/rxGKROkYEGIFAmyBFh/hVCUzC/N1zOHxD8PWyKTbcX7Hh/jXu53Q6lV1YetwMmfAAbyXGBKtjRIDstPUCAKAKwhU3kRATIknazFB7AAAAAAAkGW/6H8op0ubyAGVLara2HshW8pG8att5+XnZ1K18hUVFq6rubYLk783bHzWxWCwK8fNSiJ+XOrcONLscAAA8Ar9duInEGGOo/fb0XBWXOuRt5xMhAAAAAICWo7TMUaWt15ZUo7XX4dziavePDPI5Zmi68TWuVUCzXYUCAADcC+GKm2gX5qdgX7uyC0u142CuEsrDFgAAAAAAmpvcolJtS60MUIy2XjkqKj2+rZfVInWKDKwSpPSIDlZkkI8JlQMAABgIV9yExWJRQkywVu7K0OYDWYQrAAAAAACP53Q6lZ5dpC2pWVXmo+w+kl/t/v7eNvWIDlaP6CAlRIcoISZY3aKC5Odta+LKAQAAaka44kYSY0LKw5VsXWN2MQAAAAAAnESZw6mMvGJjEHr5EPRDOUVKzy7U9oPGwPnM/JJqj20T7GuEKDHBriClQ7i/rLT1AgAAHoBwxY1UzF3ZwlB7AAAAAIBJnE6nsgtLXUHJsaHJH29n5BXJUc1g+WPZrBbFRwYc09YrRD2ig9QqkLZeAADAcxGuuJHEmBBJ0pbUbDkcTj6tAwAAAABoMIUlZTqUU6SDOUU6nFt9WFJxu7ia2ScnYrFIrQK8FRHoo8ig8kugjzpFBqhHdLC6RgXJ14u2XgAAoHkhXHEjnSID5G23KreoVHsz89WhVYDZJQEAAAAA3JjT6XQFJidaYXK4/HZOUWmdzh3ka3cFJa7QpJrb4f7estusjfQMAQAA3BPhihvxslnVvU2Qft2Xpc0HsglXAAAAAAAndCinSLfPXqP1e4/W+hhvu/WkYUnFbVabAAAAnBjhiptJjAkuD1eyNKJntNnlAAAAAADc0P6jBbrxzVVKPpwnq0VqFXjyFSaRQT4K8rHLYqEFNQAAwKkiXHEzCTEhkvZqM0PtAQAAAADV2HEwVze9tUqpWYVqG+qn924boI4RdD4AAABoSoQrbiYxJliSCFcAAAAAAMfZtD9LY2euVkZeseIjA/TebQMUHeJndlkAAAAtDhPn3EyPNsGyWlQ+kLDQ7HIAAAAAAG5idXKGxry+Uhl5xTqtbbAW/HkgwQoAAIBJCFfcjJ+3zbWcewurVwAAAAAAkv637aBuemuVcopK1b9juObefpZaBfqYXRYAAECLRbjihhJjQiTRGgwAAAAAIH2+4YBun71GRaUOnd+9tWbf2l/Bvl5mlwUAANCiEa64oYq5K6xcAQAAAICW7f3VKfrLvF9U6nDqsl4xeu2mvvL1spldFgAAQIvHQHs3VLlyJcvkSgAAAAAAZpnx/U7933+3SZJuGNBeUy4/TTarxeSqAAAAIBGuuKWKlSu7j+Qrp7BEQSz3BgAAAIAWw+l06pmvftOr3+2UJN09JF5/T+omi4VgBQAAwF3QFswNhQV4KybEV5K0LS3H5GoAAAAAAE3F4XBq0iebXMHKPy7urgcv7k6wAgAA4GYIV9xUQvnqlc37aQ0GAAAAAC1BSZlD981frzmrUmSxSE+NOk13DYk3uywAAABUg3DFTSW45q4w1B4AAAAAmrvCkjL9+d21+mzDAdmtFr143Rm6YUAHs8sCAADACTBzxU1VzF0hXAEAAACA5i2nsER/emeNVidnyMdu1Ywb+2po99ZmlwUAAIAaEK64qYpwZfvBHBWXOuRtZ5ERAAAAADQ3GXnFunnmam3cn6UgH7veuqWf+ncMN7ssAAAAnATv2LuptqF+CvHzUkmZU7+nM9QeAAAAAJqb1KwCXfvaCm3cn6XwAG+9f8dZBCsAAAAegnDFTVksFiVEG6tXtqTSGgwAAAAAmpPdh/N09asrtONgrqJDfLXgzwN1WtsQs8sCAABALRGuuLGK1mBbmLsCAAAAAM3G1tRsXT1jhfYfLVDHiAB9cOdAdW4daHZZAAAAqANmrrixxLYVQ+2zTK4EAAAAANAQ1u7J1Li3Vyu7sFQ9ooM1+9b+igzyMbssAAAA1BHhihtLjDGWhG85kC2Hwymr1WJyRQAAAACA+vph+yHdMXutCkrK1LdDmGbe0k8hfl5mlwUAAIB6oC2YG+sUESAfu1V5xWXak5FvdjkAAAAAgHr678ZU3TrrZxWUlOmcLhF690/9CVYAAAA8GOGKG7PbrOoeTWswAAAAAPBkC9bs1T1z16mkzKkRPdvozZvPlL83jSQAAAA8GeGKm0uIZqg9AAAAAHiqt35M1oMf/iqHUxp9ZqxeGtNHPnab2WUBAADgFPFRGTeXGFOxcoVwBQAAAAA8hdPp1L+/2a7/LN0uSbr9nI56eEQPWSzM0gQAAGgOCFfcHOEKAAAAAHgWh8OpKV9s0azluyVJD1zUVfcM7UywAgAA0IzQFszNdW8TLKtFOpxbpIPZhWaXAwAAAKCBTZ8+XXFxcfL19dWAAQO0evXqE+5bUlKiKVOmKD4+Xr6+vurVq5cWL15cZZ/HH39cFoulyqV79+6N/TRQrrTMoQc+3OAKVqZcnqjx53chWAEAAGhmCFfcnJ+3TfGRgZJYvQIAAAA0N/Pnz9eECRM0efJkrVu3Tr169VJSUpIOHjxY7f6TJk3Sa6+9ppdeeklbtmzRnXfeqVGjRumXX36psl9iYqJSU1Ndlx9//LEpnk6LV1hSprvnrNPCdftls1o07dpeGjswzuyyAAAA0AgIVzxAZWuwLJMrAQAAANCQpk2bpttvv13jxo1TQkKCZsyYIX9/f82cObPa/d999109/PDDGjFihDp16qS77rpLI0aM0PPPP19lP7vdrjZt2rguERERTfF0WrTcolLdOutnfb0lXd52q169oY+u7NPO7LIAAADQSAhXPEBCebiyJZWVKwAAAEBzUVxcrLVr12rYsGGubVarVcOGDdOKFSuqPaaoqEi+vr5Vtvn5+R23MmX79u2KiYlRp06ddMMNNyglJaXGWoqKipSdnV3lgto7ml+sG99cpeU7jyjA26ZZ4/rposQ2ZpcFAACARkS44gESY0Ik0RYMAAAAaE4OHz6ssrIyRUVFVdkeFRWltLS0ao9JSkrStGnTtH37djkcDi1ZskQLFy5Uamqqa58BAwZo1qxZWrx4sV599VUlJyfrnHPOUU5OzglrmTp1qkJCQlyX2NjYhnmSLcDB7EKNfm2l1u89qlB/L825/SwNimelEAAAQHNHuOIBKtqC7TmSr+zCEpOrAQAAAGCWF198UV26dFH37t3l7e2t8ePHa9y4cbJaK/+0Gz58uK655hqdfvrpSkpK0pdffqmjR49qwYIFJzzvxIkTlZWV5brs3bu3KZ6Ox9ubka+rZ6zQb+k5ah3kowV/HqjesaFmlwUAAIAmQLjiAUL9vdU21E+StJXVKwAAAECzEBERIZvNpvT09Crb09PT1aZN9S2lIiMj9cknnygvL0979uzRtm3bFBgYqE6dOp3wcUJDQ9W1a1ft2LHjhPv4+PgoODi4ygU1+z09R1e9ulwpGflqH+6vD+8cpK5RQWaXBQAAgCZCuOIhElxD7QlXAAAAgObA29tbffv21dKlS13bHA6Hli5dqoEDB9Z4rK+vr9q2bavS0lJ99NFHuvzyy0+4b25urnbu3Kno6OgGq72l27D3qK59bYUO5hSpW1SQPrxzoNq38je7LAAAADQhwhUPkRDNUHsAAACguZkwYYLeeOMNvfPOO9q6davuuusu5eXlady4cZKksWPHauLEia79V61apYULF2rXrl364YcfdPHFF8vhcOjBBx907fPAAw/o+++/1+7du7V8+XKNGjVKNptNY8aMafLn1xwt33lY17+xUkfzS9QrNlTz/3yWWgf7ml0WAAAAmpjd7AJQO4msXAEAAACandGjR+vQoUN67LHHlJaWpt69e2vx4sWuIfcpKSlV5qkUFhZq0qRJ2rVrlwIDAzVixAi9++67Cg0Nde2zb98+jRkzRkeOHFFkZKQGDx6slStXKjIysqmfXrOzZEu67pm7TsWlDg2Kb6XXx56pQB/+rAYAAGiJLE6n02l2EU0pOztbISEhysrK8qg+wvuPFujs//tWdqtFm6ckycduM7skAAAAeAhP/R0Y5uHfzPF+3H5YN7+9WmUOpy5MiNJLY86Qrxd/lwEAADQH9fn9l7ZgHiImxFeh/l4qdTi1PT3X7HIAAAAAoEVZuG6fyhxOJSVG6dUb+hCsAAAAtHCEKx7CYrEc0xosy+RqAAAAAKBlOZJXLEka1iNKdht/SgMAALR0/EboQRJjQiQxdwUAAAAAmlpmvhGuhAd4m1wJAAAA3AHhigdJiDZWrmwhXAEAAACAJpVRvnIljHAFAAAAIlzxKBVtwbamZsvhcJpcDQAAAAC0HJnl4Uq4P+EKAAAACFc8SqfIQPl6WZVXXKbdR/LMLgcAAAAAWoTCkjLlFZdJYuUKAAAADIQrHsRmtah7m4qh9rQGAwAAAICmcDS/RJLxN1mwr93kagAAAOAOCFc8TEVrMMIVAAAAAGgarnkr/t6yWCwmVwMAAAB3QLjiYRJjQiRJmw9kmVwJAAAAALQMmfnl81YCvEyuBAAAAO6CcMXDJJSvXNlyIFtOJ0PtAQAAAKCxHbtyBQAAAJAIV5reylelOddKR3bW6/DubYJks1p0JK9YB3OKGrg4AAAAAMAfVa5cIVwBAACAgXClqW39Qtr+lbT7h3od7utlU3xkgCRagwEAAABAU3CtXCFcAQAAQDnClabWYZDxdc+Kep/CNXdlP0PtAQAAAKCxZZaHK+G0BQMAAEA5wpWm5gpXltf7FInlc1c2HyBcAQAAAIDGlpFfIomVKwAAAKhEuNLUYvtLVruUlSIdTanXKRKiy8OVVNqCAQAAAEBjc61cCfAyuRIAAAC4C8KVpuYdIEX3Nq7XszVYQvnKlb0ZBcoqKGmgwgAAAAAA1XHNXKEtGAAAAMoRrpjB1Rrsp3odHurvrbahfpKkram0BgMAAACAxpSZX7FyhXAFAAAABsIVM3Q42/jK3BUAAAAAcGtOp5OVKwAAADgO4YoZ2g+QZJGObJdyD9brFIkxIZKkzQeYuwIAAAAAjaWgpExFpQ5JDLQHAABAJcIVM/iFSVGnGdfruXqlYuXKFlauAAAAAECjqVi14m2zKsDbZnI1AAAAcBeEK2ZxzV2pX7hSMdR+x8FcFZaUNVRVAAAAAIBjZOaVSJLCArxksVhMrgYAAADugnDFLKcYrkSH+CrM30ulDqe2p+c2YGEAAAAAgAoZ+cxbAQAAwPEIV8xSEa6kb5IKMut8uMViYe4KAAAAADSyzPK2YOHMWwEAAMAxCFfMEthaatVZklNKWVWvU1TMXdnM3BUAAAAAaBQVM1cYZg8AAIBjmRquLFu2TCNHjlRMTIwsFos++eSTkx7z3XffqU+fPvLx8VHnzp01a9asRq+z0bhag/1Ur8MTXOEKK1cAAAAAoDFklrcFC6ctGAAAAI5hariSl5enXr16afr06bXaPzk5WZdccomGDh2q9evX67777tNtt92mr776qpErbSQdzja+1nPuSkVbsK2pOSpzOBuqKgAAAABAOVauAAAAoDp2Mx98+PDhGj58eK33nzFjhjp27Kjnn39ektSjRw/9+OOP+ve//62kpKTGKrPxVKxcSV0vFeVKPoF1OrxjRID8vGwqKCnT7iN5io+s2/EAAAAAgJpVrlzxMrkSAAAAuBOPmrmyYsUKDRs2rMq2pKQkrVix4oTHFBUVKTs7u8rFbYS2l0JiJUeptO/nOh9us1rUPTpIEnNXAAAAAKAxsHIFAAAA1fGocCUtLU1RUVFVtkVFRSk7O1sFBQXVHjN16lSFhIS4LrGxsU1Rau255q7UtzUYc1cAAAAAoLFk5pVIksIJVwAAAHAMjwpX6mPixInKyspyXfbu3Wt2SVWdcrhizF3ZwsoVAAAAAGhwGeVtwcIYaA8AAIBjmDpzpa7atGmj9PT0KtvS09MVHBwsPz+/ao/x8fGRj49PU5RXPxVD7ff9LJUWSfa61Vq5ciVbTqdTFouloSsEAAAAgBbJ6XQqs7wtGCtXAAAAcCyPWrkycOBALV26tMq2JUuWaODAgSZV1ABadZYCIqWyIunAL3U+vGtUkGxWizLyipWWXdgIBQIAAABAy5RTVKpSh1MSK1cAAABQlanhSm5urtavX6/169dLkpKTk7V+/XqlpKRIMlp6jR071rX/nXfeqV27dunBBx/Utm3b9Morr2jBggW6//77zSi/YVgsx7QG+6nOh/t62dQ5MlASrcEAAAAAoCFVrFrx87LJz9tmcjUAAABwJ6aGK2vWrNEZZ5yhM844Q5I0YcIEnXHGGXrsscckSampqa6gRZI6duyoRYsWacmSJerVq5eef/55vfnmm0pKSjKl/gZT0RrslIfaE64AAAAAQEPJoCUYAAAATsDUmStDhgyR0+k84f2zZs2q9phffql7+yy3VrFyJWWVVFYq2er2Y0mICdbCX/Zr84GsRigOAAAAAFqmzIph9gFeJlcCAM3Eod+kte9I7QdIXS+u8+xhmKysRNqxVNr9g9S2r9RthOTla3ZV7uvgVmnjh1JumtmVeJYBd0ltTjO7ilrxqIH2zVbrBMk3RCrMktI3SjFn1OnwxJgQSaxcAQAAAICGlJFXIol5KwDQINa/Ly2aIJXkSyunS35hUs9rpN7XS9G9jdb5cE/pm6X1c6Vf50t5hyq3+4ZIp10t9b5BatuHn6Ek5WdImz6S1s+p13xtSOpxGeEK6sBqk9oPlH5fbLQGq2O4klDeFmxfZoGy8ksU4s+nqgAAAADgVGXSFgwATl1xnvTl3403myUppo+Uk2pcVr9uXFonSL3GSKePloKizK0Xhrwj0sYPpA1zpdQNldv9I6TOw4zVK9n7pTVvGZeIblLv8p9hcIx5dZuhYkXP+jnSb/+VHMaHM2S1S12SpHZ9JRE81VqrzmZXUGuEK+6iw6DKcGXgPXU6NMTPS+3C/LQvs0CbU7M0KD6ikYoEAAAAgJYjo6ItGCtXAKB+Dm6TPrhZOrRNslilIROlc/5m3Lfrf8ZqiK1fSAe3SEselb553Hjjvvf1UrfhtA1ramUl0vYlRkjw+1fHhAReUreLjRUqnYdJNi/JUSYlf2+sSNr6mXT4N+Pnt3SKFH9++c/wkubdNsy1omeBlHewcnubnsb36rSrpcBI8+pDoyNccRfHDrV3OCSrtU6HJ8YEa19mgbYcyCZcAQAAAIAGwMoVADgFv8yRFv1NKi2QAqOkq96SOp5TeX/nYcal4Ki0eaHxJv2+1dL2r4yLb6jU82rjTfoYWk41qrSNlSFB/uHK7dG9je//aVdLAa2qHmO1GSFK/PlS4XPS5k+Mc+xdKe34xrj4hEinXWkEDe3ObB4/w7wj0qYPjQDqjyt6Tr/WWIEVfbp59aFJEa64i+hekpe/VJBhJL2te9Tp8MSYEH21OV1bmLsCAAAAAA0iI69ioD3hCgDUWnGeEapseN+43WmodOUbJ/4Ev1+odOatxuXwduMN+g3zpJwD0s9vGpeIbsab/KePloKjm+ypNGu5h4y2X+vnGjOgKwS0NkKC3tdLUYm1O5dviNT3ZuNyZKfxs1//vpS9T1r7tnFp1bn8Z3idFNK2cZ5TY6lpRU/XJCM86nKhsaIHLQrhiruweUnt+hnL6fb8VI9wxZi7wlB7AAAAAGgYmeVtwcJpCwYAtZO+RfrgFuODwxarNPQRafCE2ndoiegiDZssnT+pvOXUXGnr5+UtpyZLS5+Q4i8wZns095ZTjaG02FgVtP5946uj1Nhu8zbasPW+wfj+2k7hLeNW8cbPb8jD0u5lxmNt+VQ6ssNoGbb0SSl+qNTreqn7JZK3f8M8t8ZwwhU9vSrbfv1xRQ9aFMIVd9Lh7PJwZbnU77Y6HZoYEyJJ2nEoV4UlZfL1sjVGhQAAAADQYlSuXOGTqABQI6dT+uVd6csHjTZgQdFGG7C4s+t3viotp7L+0HJqiXHxDZFOu8p4k765tJxqDE6n0b5qw/tGSFCQUXlfTJ/ytl9XSf7hDfu4VqvUaYhxGfGsEbCsnyulLJd2fmtcfIKlxFFGUBHb3z1+hhUrejbMNcKVCgGRxsqpXmOkNqeZVx/cCuGKO+kwyPi6Z7nxwleHF5SoYB+1CvDWkbxi/ZaWo16xoY1TIwAAAAC0EJn5RtsPZq4AQA2KcqVFE6Rf5xu34y+QrnxdCmigmcB/bDlV0TYse5+0ZqZxadXFCAl6XScFxzTM43q63INGmLJ+rnRwc+X2wCgjJOh9fZ0759Sbb7DU5ybjkrHL+Pmtf1/KSpHWvWNcwuONFUmnXyeFxjZNXRVKi6XtXxvfqz+u6Ol6sRH+dL6Atl84DuGKO2l3ptGrLydVykyWwjvV+lCLxaKEmGD9sP2wtqRmE64AAAAAwCkoczh1lLZgAFCz9M3SgpulI9sli81oB3X2fbVvA1ZXreKlCx412o3tXma8Gb7lM+Pxlz4hffuksVKi9w1Gyykvv8apw12VFkm/Ly4PCZZIzjJju83b+H70vsGYgXMqbb9OVXgnaejD0nkPGaMR1s+VtnwiZeyUvv2n9O1TUqfzjBVJPUY2Xtswp1NK+9V4/I0fSPlHKu+LOaO87VcjrOhBs0K44k68/KS2fY0ljnuW1ylckeQKVzYfyGqkAgEAAACgZcguKJHDaVwPJVwBgKqcTmO1wX//IZUWSkEx0tUzpQ4Dm+bxq7Sceu7ELadOu9J4k7xdP/doOdUYnE4pdX1lSFCQWXlf2zPL235dKfmFmVZitaxWqeM5xmXEM0ZItuF9afcP0q7vjMuiICnxCuNn2P6shvkZVqzo2fC+lL6pcrsZK3rg8QhX3E2HQZXhyhk31unQirkrDLUHAAAAgFOTUb5qJcjHLm97I30CGwA8UVGO9MX9xhv5ktT5QmnUa+YN9q6p5dTaWcYlPL6ybVhIO3PqbGg5aZVtvw5trdweFF0ZEkR2M6++uvAJks64wbhk7i7/Gc6Vju4xZvn88q4U1rHyZxjavm7nd63oed9o/3Xsip5uI4zwJv58c1f0wCPxL8bddDhb+nGasSyujhJjgiVJ21JzVOZwymZtpok8AAAAADSyTNcwe1atAIBL2kbpg1ukIzuMNmAXPCYN+kvjtQGrqyotp34sbzn1aXnLqSeNtlOdzitvG3Zp47WcaiwlhdLv/zWe146lx4QEPlKPS43wodNQyWozt85TERYnDXlIOvdBKWWF8Vw3f2yMUPjfU8al47lG27CEyyTvgOrPU+OKnr7G9yrxStp+4ZQQrrib2P6SxWqktFn7pZC2tT60Y6sA+XvblF9cpuTDuercOqjx6gQAAACAZiyDcAUAKjmd0tq3pf8+JJUVScFtjTZg7c8yu7LqWa3GG/Adz5VGPGu0nFo/1whcKlpOeQdJp40y3qRvqJZTjcHplPavkzbMlTZ+KBUerbyvXf/ykGCU5BdqVoWNw2qV4s42LsP/JW393PgeJC+rvHz5gJRwhfE9aD/QOCYnXfp1vtH26+CWyvMFtjFWvXjSih64PcIVd+MbLLU53UhWU1ZIPa+u9aFWq0U9ooO1dk+mNh/IJlwBAAAA4Hly0qWf3zDatvS9xbQyjuaXSJLC/b1MqwEA3EJhtvT5X6XNC43bXZKkUTM85xP/x7acykg23nivaDm1brZxCe8kdb1YsvuYXW1VZSXGYPrDv1VuC25b2fYroot5tTUln0Cp9xjjkrmn/Gc4x/hw+vr3jEtoB6lVvLTr++NX9PS63pjPQ9svNDD+RbmjDmcb4cqe5XUKVyQpoTxc2XIgW5f3rv2qFwAAAABwC78vlpY9K4XESr1vNO2NkIqZK6xcAdCipW4w2oBl7JKsdumCydLA8e7TBqyuwjse03JquTGDY/PHxvNb+YrZ1Z2Y3VfqMdIIVDqe59ltv05VWAfpvAelc/8upaw0QpbNnxhh2dE9xj7t+htBTOKVzW9FD9wK4Yo76jBIWjndCFfqqGLuCkPtAQAAAHik06+Vlk6RsvZKWz+TTrvSlDIqZq6E+xOuAGiBnE5pzVvS4ofL24C1k65522hn3xxYrVLcYONS0XIqbaPZVVUvspuUeIXkG2J2Je7FYpE6DDQuw5+Rtn0hZR+Qul/Sclb0wHSEK+6o/UDj66GtUt4RKaBVrQ9NjDFeaDcfyJLT6ZTFXftFAgAAAEB1vPykfrdJ3/+ftOJlo4+8CX/XMHMFQItVmCV99hdpyyfG7a7DpSte8Zw2YHVV0XJKY8yuBPXl7W98OANoYh66hq+ZC2glRfYwrqesqNOhXdsEym61KDO/RKlZhY1QHAAAAAA0sn5/Mvqk718r7V1tSgmZ5W3BwglXALQkB9ZLr51nBCtWu3TRU9KY95tvsAIAp4BwxV11GGR8rWNrMB+7TZ1bB0qiNRgAAAAADxXYuvITqCteNqUE18oV2oIBaAmcTmn1G9JbF0qZyVJIe+nWr6RB401ZPQgAnoBwxV25wpWf6nxogmvuSlZDVgQAAAAATWfgPcbXbV9IGclN/vCZ+SWSWLkCoAUozJI+uFn68gGprFjqdol05zKp3ZlmVwYAbo1wxV1VhCtpv0qFdVuBUjF3ZQsrVwAAAAB4qtY9pPgLJKdDWvVakz98xcqV8ACvJn9sAGgy+9dJr50rbflUsnpJSVOl6+ZIfmFmVwYAbo9wxV0Fx0hhccYfEnXsMZzoWrlCuAIAAADAgw0ab3z95V2p4GiTPWxpmUNZBcbKFdqCAWiWnE4juH7rIilztxRa3gZs4N20AQOAWiJccWcdzja+1rE1WEVbsP1HC3S0fAgjAAAAAHicTkOl1glSca607p0me9ij5cGKxSKF+LFyBUAzU3BUWnCT9N8HJUeJ1P1S6c8/SO36ml0ZAHgUwhV3Vs+h9sG+Xmof7i+J1mAAAAAAPJjFUjl7ZdVrUllJkzxsZnlLsBA/L9lt/NkMoBnZt1Z67Rxp6+dGG7CL/yWNfk/yCzW7MgDwOPyW6M4qwpX9a6WSgjodSmswAAAAAM1Cz2ukgNZS9n5jJkATcM1boSUYgObC6ZRWvirNTJKOpkihHaQ/fSWddSdtwACgnghX3FlYRyko2liiuW9NnQ5NiDbClS2phCsAAACAO5s+fbri4uLk6+urAQMGaPXqE89cLCkp0ZQpUxQfHy9fX1/16tVLixcvPqVzuj27j9T/duP6ipeNNwgbWWZ5e+WwAMIVAM1AQaY0/0Zp8UPGe0w9LpP+vExqSxswADgVhCvuzGKpd2uwxLYVK1eyGroqAAAAAA1k/vz5mjBhgiZPnqx169apV69eSkpK0sGDB6vdf9KkSXrttdf00ksvacuWLbrzzjs1atQo/fLLL/U+p0c481bJ7isd+EVKWdHoD5eRxzB7AM3EvjXSjHOlbV9INm9pxHPStbNpAwYADcBudgE4iQ6DpE0f1XmofWJMiCRp56E8FZaUydfL1hjVAQAAADgF06ZN0+23365x48ZJkmbMmKFFixZp5syZeuihh47b/91339UjjzyiESNGSJLuuusuffPNN3r++ef13nvv1eucHiEgQup1nbR2lrRieuWH0BpJxcqV8ACG2QM4CYdD2v2DlL7Z7EqOl5tmvGY6SqWwOOmaWVLMGWZXBQDNBuGKu+twtvF172qptFiy1+6TU62DfBQR6K3DucXalpaj3rGhjVcjAAAAgDorLi7W2rVrNXHiRNc2q9WqYcOGacWK6ldnFBUVydfXt8o2Pz8//fjjj/U+Z8V5i4qKXLezs92wvfBZdxvhyrZF0pGdUqv4RnuoipkrtAUDcEJHdkrr50ob5knZ+8yupmYJV0iX/UfyDTG7EgBoVghX3F1EN8kvXCrIkFI3SLH9anWYxWJRQkyIlv1+SJsPZBGuAAAAAG7m8OHDKisrU1RUVJXtUVFR2rZtW7XHJCUladq0aTr33HMVHx+vpUuXauHChSorK6v3OSVp6tSpeuKJJ07xGTWyyG5Sl4uk7V9Lq2ZII55ttIfKZKA9gOoUZkmbPzFClb0rK7f7hkidhhhtt9yKRYo/31j5x9B6AGhwhCvuzmo1lrxv+8JoDVbLcEWSEmOCy8MVN/zUGQAAAIA6e/HFF3X77bere/fuslgsio+P17hx4zRz5sxTOu/EiRM1YcIE1+3s7GzFxsaearkNb+A9Rrjyy3vS0Iclv7BGeZgMBtoDqOAok5K/NwKVrZ9LpYXGdotVir9A6n291G2E5OVb83kAAM0O4YoncIUry6XB99X6sIRoY6j9FsIVAAAAwO1ERETIZrMpPT29yvb09HS1adOm2mMiIyP1ySefqLCwUEeOHFFMTIweeughderUqd7nlCQfHx/5+Pic4jNqAh3Pk6JOk9I3SWvels6ZcPJj6oGVKwB0eHtl26+cA5XbI7sbgUrPa6XgaPPqAwCYzmp2AaiFimGNKSuNT0zUUmKMEa5sS8tWmcPZGJUBAAAAqCdvb2/17dtXS5cudW1zOBxaunSpBg4cWOOxvr6+atu2rUpLS/XRRx/p8ssvP+VzegSLRRo43ri++nVjLmUjYOUK0EIVHJXWzJTevFB6+Uzpx2lGsOIbKvW7Tbr9W+nuldLZfyVYAQCwcsUjRPWUvIOkoizp4BapTc9aHRbXKkAB3jblFZdp16FcdYkKauRCAQAAANTFhAkTdPPNN+vMM89U//799cILLygvL0/jxo2TJI0dO1Zt27bV1KlTJUmrVq3S/v371bt3b+3fv1+PP/64HA6HHnzwwVqf0+OddpX0zeNSTqq0+WOp1+gGf4jMvBJJUjjhCtD8Ocqknf+TNsyVtn4hlRUZ2y02qfOw8rZfwyW7B6zuAwA0KcIVT2CzS+0HSDu+MVqD1TJcsVot6hEdrDV7MrX5QDbhCgAAAOBmRo8erUOHDumxxx5TWlqaevfurcWLF7sG0qekpMhqrWw4UFhYqEmTJmnXrl0KDAzUiBEj9O677yo0NLTW5/R4dm+p/+3St09KK16WTr+2QQc1F5WWKbeoVBJtwYBm7dBvRtuvX+cbYW2FyB7SGTcYbb+CmsnrJgCgUVicTmeL6heVnZ2tkJAQZWVlKTg42Oxyau+H56WlU6SEy6VrZ9f6sMmfbtI7K/bo9nM66pFLEhqxQAAAALgrj/0dGKZx+38z+RnStASptEC6+Qup4zkNdur07EINeHqpbFaLtv9zuKzWhgtuAJisIFPa9JERquxfW7ndL0zqeY2xSiW6d4MGtgAAz1Cf339ZueIpOpxtfN2zXHI6a/0/+oTyuSubGWoPAAAAoLnwDzfeBF3zlrRieoOGKxnlw+zD/L0IVoDmoKxU2vmttH6O9NuXUln5rCaLTepykfFa0jWJtl8AgDojXPEUMWdINh8p75B0ZIcU0aVWhyXGhEiStqRmy+l0ysKnLwAAAAA0B2fdbYQrv/9XOrxDiujcIKfNdIUrtAQDPNrBrUag8usCKTe9cnvrxPK2X9dIga3Nqw8A4PEIVzyF3Udq10/a86O056dahytdogJlt1p0NL9EB7IK1TbUr5ELBQAAAIAmENFZ6jrcCFdWviJdOq1BTpuRXx6uMMwe8Dz5GdLGD43h9Ad+qdzu38qYodJ7jNTmdNp+AQAaBOGKJ+kwqDxcWS71vaVWh/jYbeoSFaStqdnavD+LcAUAAABA8zHwHiNcWT9XOn+S0S7sFFWsXGGYPeAhykqkHUvL2379V3KUGNutdqlLktH2q8tFkp3/pgEADYtwxZN0GGR83bO8ToclxgQb4cqBbF2U2KYRCgMAAAAAE8QNNj6FnvartGamdO4Dp3zKjDzjjVlWrgBuLn2zEaz+ukDKO1i5vU1PqXd526+ACPPqAwA0e4QrniS2v/HJi6y90tEUKbR9rQ5LjAnWh2sZag8AAACgmbFYpIHjpY/vkFa/Lg2695SHUmeWtwULD/BqiAobX9Z+Kf+IFH262ZUAja+kUFr3jrFKJXVD5Xb/COn00eVtv3qaVx8AoEUhXPEk3gFSdG9p/xpj9Uotw5WE6GBJ0pYDWY1YHAAAAACYIHGU9M3jUs4BadNHRgugU5DhSQPtc9KlGYOlggyp/x3SRf885XAJcFtlJdK866WdS43bVi+p28VSr+ulLhdKNg8JRAEAzYbV7AJQR67WYD/V+pCEGCNcOZBV6OofDAAAAADNgt1bGnCHcX3FdMnpPKXTVa5ccfNwxemUvrjfCFYkY+XOWxdJGbvMrQtoDE6n9Nm9RrDi5S9d/H/S336TRr8ndR9BsAIAMAXhiqfpcLbxtQ5zV4J8vdShlb8kaUsqrcEAAAAANDN9bzHecE3fJCV/f0qncq1ccfdwZeMH0m+LjE/vX/x/kl+YlLpeeu08afPHZlcHNKxvn5Q2vC9ZbNI1s6Sz7pICWpldFQCghSNc8TTtB0iySEd2GEvAaymxfPXKZlqDAQAAAGhu/MKkM240rq+YfkqnqljtH+7ObcFy0qQv/25cP+8fxhvNd/4oxQ6QirKlD26RFv3NmE8BeLrVb0g/PG9cH/mC1DXJ1HIAAKhAuOJp/MKkqNOM6ym1X72SGBMiiaH2AAAAAJqpAXdKskjbv5YO/Vbv02S4e1swp1P6/D6p8Kgxk3Pwfcb2kHbSLYuks8tv//ym9NaF0pGdppQJNIitn1cGiUMelvqMNbceAACOQbjiiVxzV2ofriS4Vq4QrgAAAABohlrFS90vMa6vfKVepygoLlNhiUOSG7cF+3W+9Pt/JZu3dMWrVWdN2LykC5+QbvhQ8guX0n412oRt+si8eoH62rNC+vBPkpxSn5ul8x40uyIAAKogXPFE9QhXEqONcGXXoVwVFJc1RlUAAAAAYK6B9xhfN8yT8g7X+fCKVSveNqsCvG0NWVnDyE6V/lv+BvN5/5CiEqrfr8uFRpuw9gOl4hzpw1ulL+6nTRg8x6HfpPevk8qKpK7DpUumSRaL2VUBAFAF4YonqghX0jdL+Rm1OqR1sK8iAn3kcErb0li9AgAAAKAZaj9QijlDKi2U1sys8+GZrmH2XrK42xu5Tqf0xX1SYZbxHCvaf51ISFvp5i+kwROM22tmSm8Okw7vaOxKgVOTnSq9d5XR+q7tmdLVMyWb3eyqAAA4DuGKJwpsLbXqIskp7V1V68MSaQ0GAAAAoDmzWKSB443rq1+v80qNjIpwxR2H2W+YJ/2++Jh2YLV4s9lml4ZNlm78SPJvJaVvlF4/T9r4YePXC9RHYZY052opa68UHi9dv0Dy9je7KgAAqkW44qnq0xqMcAUAAABAc5dwuRTcVso7JG38oE6HZrrrMPvsA9LifxjXhzwkte5Rt+M7DzPahHU4WyrOlT76k/T5X6WSgoavFaiv0iJp/o1S+iYpoLURCga0MrsqAABOiHDFU3U42/hap3AlRJK05UBWY1QEAAAAAOazeUkD/mxcXzHdaKdVS66VK+4UrjidRhBSmCXF9JEG/bV+5wmOkcZ+Jp37d0kWae2s8jZh2xuyWqB+HA7pk7ul5GWSd6B0wwdSeEezqwIAoEaEK56qYuVK6nqpKLdWhySUr1zZlpaj0jJHIxUGAAAAACbrc7PxBu2hrdLOb2t9WMXMlXB3agu2fq60/eu6tQM7EZtdOn+SdNNCyT/CWCHw2nnSrwsarl6gPr55TNr0oWS1S9fOlmJ6m10RAAAnRbjiqUJjpZBYyVEq7fu5Vod0CPdXoI9dRaUO7Tqc18gFAgAAAIBJ/EKlM24yrq+YXuvDMvLdbOVK9gFp8UTj+tCHpdbdG+a88edLd/0kxZ0jleRJC2+XPrtXKs5vmPMDdbHiFWn5S8b1y6dLnS8wtx4AAGrpFD7yAtN1GCT9Ot9oDRY/9KS7W60W9YgO0s+7M7X5QJa6RgU1QZEAAAAAYIIBf5ZWvybtXCqlb5GiEk56SGZeiSQp3N+rsas7OadT+uwvUlGW1LavNPDehj1/UBtp7KfS989I3/9LWjdb2rdGuuYdKbJrwz6WuygpkPavkxwlZldyvND2Ungns6toepsWSl89bFy/YLLU6zpz6wEAoA4IVzzZseFKLSXGhBjhyv5sjTqjEWsDAAAAADOFd5S6Xypt/Uxa+Yp0+csnPcStZq6snyPtWCLZfE69HdiJWG3S0IlSh4HSR7dLB7dIrw+RLp3WfN7kdjqlvauN7+fmj6WibLMrOgGLdN6D0nn/MH4uLUHyD9LHf5bklPrdLg2+3+yKAACoE8IVT1Yx1H7fz1JpkWT3OekhFXNXNh9w118oAQAAAKCBDBxvhCu/LpAueEwKbF3j7pnlbcHCzQ5XsvZXbQcW2a1xH6/TEOnOH6WFtxkDxT/+s/HG94hnJW//xn3sxnJ0r/TrPGn9+1LGzsrtQdGSX7h5dVXHUSId/t1YQbRnuXTVm8bKouYsfbM07waprFjqMVIa/i/JYjG7KgAA6oRwxZO16iwFREp5h4ylzR0GnvSQRFe4kiWn0ykLv7wAAAAAaK5i+0ttz5T2r5F+fstYpVED18oVMwfaO53G/JOibKP2QQ3cDuxEgqKkmz6Rlj0nfTdVWv+etH+tdM2shpv10tiK86WtnxurVJKXSXIa270CpMQrpF5jjA8pWt1w/OyvH0hf3Cft/kGaMVi68nVjNk5zlLVPeu9qo+Vd+4HSlW+0nNU6AIBmxQ1/o0CtWSxGazBJ2vNTrQ7p0jpIXjaLsgtLtS+zoBGLAwAAAACTWSzSwHuM6z+/YczcOAGn0+keK1d+edeYE1PRDqwp33S22qQh/5Bu/kwKjJIObZXeGCqtn9t0NdSV0yntWSF9Ol56rqv08R1S8veSnFLcOcb38IHfpStekTqe457BiiSdfo10x/dSVE/jA5TvXiktfVIqKzW7soZVkGkEKzkHpIhu0nVzJS8/s6sCAKBe3PS3CtRaRWuwWs5d8bZb1aW1Mch+SyqtwQAAAAA0cz0uk0JipfwjxszKE8gtKlVJmbHSwbSVK1n7pK8eMa6fP8m8wfIdzzXahHUaIpXkS5/cJX18l1ScZ0491TmaIn3/jPSfM6S3LzZCqeIcKbSDNORh6a+/Srd8IfW+XvIJNLva2onoLN22ROo7TpJT+uE5afZlUnaq2ZU1jJJCoxXYoa1Ge7YbP5L83axFGwAAdUC44ukqVq7sXVXrT7QkMncFAAAAQEths0sD7jSur3hFcjiq3S0zr0SS5Odlk5+3CS2KnE7ps78Y7cDa9a9ccWOWwNbSjQuloZMki1XaMFd6fah0cKt5NRXnGTNUZl0qvdBT+t9TUmay5B0onXGjdMuX0l/WG6tvwjqYV+ep8PKTRr4gXfWW8bz2/GS0CdvxjdmVnRpHmbGqaM9Pkk+wdMOHUmis2VUBAHBKCFc8XesEyTdEKs6V0n6t1SEV4cqWA1mNWRkAAAAAuIc+N0neQdLh34yWW9XIMLsl2LrZRm12X6OFlTvMoLDapPP+Lt38uRTYxvj+vT5U+uU9IwxqCg6HtPtH6ZO7jbZfn9xpzCWRjBU2o14z2n5dPl2Kc9N5KvXR82rpz8ukNj2l/MPSe1dJ3zzhmW3CnE5p8URpy6eS1Uu6bo7U5jSzqwIA4JQ1k986WjCrzRgAJ9W6NVhi2xBJrFwBAAAA0EL4hkh9bzaur3i52l0yK4bZB3g1VVWVju6t2g4sokvT11CTuMFGm7D486XSAunTe6SP75SKchvvMTN3S9/9n/Sf3tKsS4wh9cW5UlhHYzXNfRuN0KfXdZJ3QOPVYaZW8dKfvpH63Wbc/nGa9M6lUtZ+c+uqq+X/kVa/ZlwfNcMIxQAAaAYIV5oD11D72oUrPaKNlSupWYXKKP8DAgAAAACatQF/Ntpb7fpOStt03N0Vfxs1+bwVp1P67F5jXkjsAOmsu5v28WsrMFK64SPp/EeN7+Ov84xh9+mbG+4xinKlX+ZIb18ivdhL+m6qdHSPseqoz1jp1q+kv/xirKYJbd9wj+vOvHylS56Xrn7b+D6krDDahG1fYnZltbNhvrTkMeP6RU8ZK3IAAGgmCFeag4qh9inLT9g/+FiBPnbFtfKXJG2mNRgAAACAliC0vZRwuXF95SvH3Z1pVluwtbOkXf8z2oFd7ibtwE7EapXOfUC6+QtjIPnh36U3zjdamtW3TZjDISUvM1bCPNdF+vRuac+PkixSpyHSlW8Ybb8ue0lqf5ZksTTkM/Icp10p/fl7qc3pUkGGNOdqaclkqazE7MpObOe3xs9Tks66Rxo03tx6AABoYIQrzUF0L8nLXyrIlA5tq9UhiTFGa7AttAYDAAAA0FIMLH9z99cFUk5albtMWblyNEX6epJx/fxHpYjOTffYpyLubKNNWOdhUmmhsfJm4R11axOWsUv69iljhco7I6UN70sl+VJ4vPG9uH+TNPZT6fRrJW//xnsunqRVvPSnJVK/243bP71gtEzL2mdqWdVK3SDNv0lylEqJV0oX/dPsigAAaHCEK82BzUuK7W9c3/NTrQ5JKB9qz9wVAAAAAC1GuzON1luOEunnN6vc1eQrV1ztwHKl2LOks+5qmsdtKAER0vUfSMMelyw2aeMC6fXzqm255lKYbaxymTlc+s8Z0rJnpKwUySdY6nuLERzcu9ZYHRPSrqmeiWfx8pUueU665h3j+7Z3ldEm7PevzK6sUuYeac41xr/tuHOMOStW3n4CADQ//N+tuahoDVbbofaucIW2YAAAAABakIH3GF9/fksqzndtdq1caapwZe3bxvwXu590hZu3AzsRq1UafL90yyIpKEY6skN68wJpzduVbcIcDmnn/4yVLc91NQKllOWSLFL8BdJVbxltv0a+aHxosKW2/aqrxCuMNmHRvY0uFnOvlb5+1Pw2YfkZ0ntXSbnpUutEafR7kt3H3JoAAGgkdrMLQAM5dqi903nSX0gr2oLtOpyn/OJS+XvzTwEAAABAC9D9Uim0gzEofcP7Ur8/SZIy84w3pcOboi1Y5h7jjXBJuuAxo92TJ+sw0GgT9smd0vavpS/uk3b/KIXFSRvmSdnHtK1q1UXqfb10+mgppK1ZFTcP4Z2kP31t/Fta/Zq0/D9Sykrp6plSaGzT11OcL80dLR3ZLgW3k278UPILbfo6AABoIqxcaS7a9pWsXlJumpSZfNLdI4N8FBnkI6dT2pqa0wQFAgAAAIAbsNoqW3CtfMVYWSEpI79i5YpX4z6+wyF9Nt5omdR+oDTgzsZ9vKYS0EoaM1+6cIrRJmzTh9IPzxnBik+IdOat0m1LpfE/S+dMIFhpKHYfacQz0rXvGt/nfauNNmG//bdp6ygrlT76k/H4viFGsBIc07Q1AADQxAhXmgsvPyNgkercGmxLKnNXAAAAALQgZ9xozKs4ssNYaSEpM6+JZq6snSklLzPagV0+vXnNorBapbP/Ko37r9TmdKnzhdLVbxttvy79tzHzhrZfjSPhMunOZVJMH6nwqPT+ddJXj0ilxY3/2E6n9OUD0m9fSjYfacw8qXWPxn9cAABM1ox+i0OV1mC14ApXmLsCAAAAoCXxCZL63mxcX/GyHA5n5UD7xmwLlrlb+vox4/qwyZ7fDuxE2g+Q7vzBWL1w2pXGEHY0vrA46davpLPuNm6veFl6e7h0NKVxH/eH54wZQrJIV71R+d4EAADNHOFKc+Iaav9TrXavmLuy+QArVwAAAAC0MAPuNNpX7f5BeXvWylE+fz20scIVh0P6dLxUkie1HyT1/3PjPA5aNru3dPFUafQcoz3X/jVGm7Btixrn8X55T/r2n8b14c9ICZc3zuMAAOCGCFeak9j+ksVqfBoqa/9Jd69YubItLUclZY5GLg4AAAAA3EhIOylxlHF95SuSpCAfu7ztjfRn8pq3pN0/SF7+0hXNrB0Y3E+PS6U//2C0Dy/MkuZdLy2e2LBtwrYvkT77i3H97PukAXc03LkBAPAA/DbXnPgGG31tJSllxUl3jw3zV5CPXcWlDu08lNvIxQEAAACAmxl4jyQp8PdPFaUMhTXWvJXM3dKSycb1YY9L4Z0a53GAY4V1kMYtlgaON26vfEWamWT8ezxV+9dKC8ZKzjLp9NHSBZNP/ZwAAHgYwpXmpg6twaxWi3pEG6tXNu+nNRgAAACAFqZtH6n9IFmcpRpr/7pxwpVj24F1GCz1u73hHwM4Ebu3lPSUdN37km+odGCdNONcaevn9T9nxi5pzrVSSb7Uaah02cusxAIAtEj836+5qeNQ+4SKofaphCsAAAAAWqDy1Ss32JYqyre04c9/bDuwy3kTGibpPkK68wepXT+pKEuaf6P0339IpUV1O0/uIendK6X8w0bnjNHvGgEOAAAtEL/VNTftBxpfD22T8g6fdPeKuSubD2Q1ZlUAAAAA4J66DVeWXzuFWvKUVPxtw547Y5e05DHj+rAnpPCODXt+oC5C20vj/isNute4vWqG9NZFUkZy7Y4vypXmXiNlJhvnuuFDySeo8eoFAMDNEa40NwGtpMgexvVazF1JjAmRJG05kC2n09mYlQEAAACA+7HatKr1aEnSkKMfSo6yhjmvqx1YvhR3jtTvtoY5L3AqbF7SRf+Url8g+YVJqeul186Vtnxa83FlJdIHt0gHfjGOu3GhFBTVFBUDAOC2CFeaozq0BusSFShvm1XZhaXal1nQyIUBAAAAgPv53u9CZTn91apon/T74oY56c9vGLMwvQKky16iHRjcS9ck6c4fpdgBUlG2MZz+y79X3ybM6ZS+uE/asUSy+xnBTESXJi8ZAAB3w293zZErXDn5UHsvm1Vd2wRKojUYAAAAgJYpvciuuWUXGDdWTD/1E2bskr553Lh+Ie3A4KZC2km3LJLO/qtxe/Xr0lsXGv9+j/XdVOmX9ySLVbp6phTbv+lrBQDADZkerkyfPl1xcXHy9fXVgAEDtHr16hr3f+GFF9StWzf5+fkpNjZW999/vwoLC5uoWg9REa6kbZQKTx6YJERXzF1hqD0AAACAlicjr1jvlF4kh8VufEht/7r6n+yP7cDO/FPDFQo0NJuXdOEU6foPJL9wKXWD9Np50uaPjfvXzJS+/5dx/ZLnpe4jzKsVAAA3Y2q4Mn/+fE2YMEGTJ0/WunXr1KtXLyUlJengwYPV7j937lw99NBDmjx5srZu3aq33npL8+fP18MPP9zElbu54BgprKPkdEh7aw6rpKpzVwAAAACgpcnML1GaWikj7hJjw8pX6n+y1a9XtgO7/GXagcEzdL2ovE3YWUabsA9ukebdIC36m3H/uQ9KZ95qaokAALgbU3/LmzZtmm6//XaNGzdOCQkJmjFjhvz9/TVz5sxq91++fLnOPvtsXX/99YqLi9NFF12kMWPGnHS1S4vU4Wzjay1agyXGsHIFAAAAQMuVkVcsScrve6exYfPHUta+up/oyM7KdmAXTZHC4hqkPqBJhLQ12oQNnmDc3vaF8aHNM26UhvKhVgAA/si0cKW4uFhr167VsGHDKouxWjVs2DCtWLGi2mMGDRqktWvXusKUXbt26csvv9SIESdellpUVKTs7OwqlxahDkPte0QHy2qR0rILlZZFizUAAAAALUdpmUNZBSWSJP+4vkYrL0epsQKlLhwO6dN7pNICqeO5Ul8+5Q8PZLNLwyZLN3wkhXaQel4jXfqCZLGYXRkAAG7HtHDl8OHDKisrU1RUVJXtUVFRSktLq/aY66+/XlOmTNHgwYPl5eWl+Ph4DRkypMa2YFOnTlVISIjrEhsb26DPw21VhCv710nF+TXuGuBjd7UGW707o7ErAwAAAAC3cbQ8WJGkUD8vaeA9xo01s6Si3NqfaNUMKWWF5B0oXUY7MHi4LsOk+36VrnrTmMsCAACO41G/7X333Xd6+umn9corr2jdunVauHChFi1apCeffPKEx0ycOFFZWVmuy969e5uwYhOFxUlB0ZKjRNq/5qS794sLlyStTj7SyIUBAAAAgPvILG8JFuLnJbvNKnVJksLjpaIs6Zf3aneSIzulpVOM6xc9KYV1aKRqAQAA4C5MC1ciIiJks9mUnp5eZXt6erratGlT7TGPPvqobrrpJt12223q2bOnRo0apaefflpTp06Vw+Go9hgfHx8FBwdXubQIFkudWoP172iEKz8nZzZmVQAAAADgVirmrYQHeBsbrFZp4N3G9ZWvSI6ymk/gKJM+udtoB9ZpiNR3XOMVCwAAALdhWrji7e2tvn37aunSpa5tDodDS5cu1cCBA6s9Jj8/X9Y/LK222WySJKfT2XjFeqo6hCv94sIkSb+l5+hofnFjVgUAAAAAbiOz/O+fMP9jWh/1GiP5hUlH90jbFtV8glUzpL0rJe8g6bKXmE0BAADQQpjaFmzChAl644039M4772jr1q266667lJeXp3HjjE/6jB07VhMnTnTtP3LkSL366quaN2+ekpOTtWTJEj366KMaOXKkK2TBMTqcbXzdu1oqrTkwaRXoo/jIAEnSz7tZvQIAAACgZcjIM2auuFauSJJ3gHRm+UD6FdNPfPDhHVXbgYW2b6QqAQAA4G7sZj746NGjdejQIT322GNKS0tT7969tXjxYteQ+5SUlCorVSZNmiSLxaJJkyZp//79ioyM1MiRI/XUU0+Z9RTcW0Q3yS9cKsiQUjdIsf1q3L1/x1baeShPP+/O0IUJUU1UJAAAAACYp3LlinfVO/rdLv30H2NVyr41Urszq97vKJM+uUsqLZQ6DZX63tI0BQMAAMAtmD7Qfvz48dqzZ4+Kioq0atUqDRgwwHXfd999p1mzZrlu2+12TZ48WTt27FBBQYFSUlI0ffp0hYaGNn3hnsBqPaY12E8n3b1/R6M12KrkjMasCgAAAADcxnEzVyoER0s9rzauV7d6ZeUr0r7VtAMDAABooUwPV9DI6jTUvpUkafP+LOUVlTZmVQAAAADgFjLLw5WwP4YrkjTwHuPrlk+loymV2w9vl779p3E96Z9SaGwjVwkAAAB3Q7jS3FWEKykrjWXrNWgb6qe2oX4qdTj1S8rRxq8NAAAAAEyWUd4WLPyPbcEkqU1PqeN5krNMWvWasc1RJn1yt9EOLP58qc/NTVgtAAAA3AXhSnMX1dNYpl6UJaVvPunu/TuGS5JW76Y1GAAAANAUpk+frri4OPn6+mrAgAFavXp1jfu/8MIL6tatm/z8/BQbG6v7779fhYWFrvsff/xxWSyWKpfu3bs39tPwWDWuXJGkgeONr+tmS4XZRouwfasln2DagQEAALRghCvNnc0utS+fY1OL1mD94srDleQjjVkVAAAAAEnz58/XhAkTNHnyZK1bt069evVSUlKSDh48WO3+c+fO1UMPPaTJkydr69ateuuttzR//nw9/PDDVfZLTExUamqq6/Ljjz82xdPxSK6VKwFe1e/QeZgU0VUqypa+mXxMO7CnpJB2TVQlAAAA3A3hSktQp6H2RrjyS8pRFZc6GrMqAAAAoMWbNm2abr/9do0bN04JCQmaMWOG/P39NXPmzGr3X758uc4++2xdf/31iouL00UXXaQxY8Yct9rFbrerTZs2rktERERTPB2PlJlXIkkKq64tmCRZrdJZdxvX18yUyoqMwOWMm5qoQgAAALgjwpWWoMPZxtc9yyWns8Zd4yMD1CrAW0WlDm3cf7TxawMAAABaqOLiYq1du1bDhg1zbbNarRo2bJhWrFhR7TGDBg3S2rVrXWHKrl279OWXX2rEiBFV9tu+fbtiYmLUqVMn3XDDDUpJSanudC5FRUXKzs6ucmkJikrLlFtUKkkKP1FbMEnqdZ3kZ3wQTT7B0sj/0A4MAACghSNcaQlizpDsvlL+Yenw9hp3tVgsx7QGy2yK6gAAAIAW6fDhwyorK1NUVFSV7VFRUUpLS6v2mOuvv15TpkzR4MGD5eXlpfj4eA0ZMqRKW7ABAwZo1qxZWrx4sV599VUlJyfrnHPOUU5OzglrmTp1qkJCQlyX2NjYhnmSbu5ovrFqxWqRgn1P0BZMkrz8pPMelKx26ZJpUkjbJqoQAAAA7opwpSWw+0jt+hnXa9EarF9H5q4AAAAA7ui7777T008/rVdeeUXr1q3TwoULtWjRIj355JOufYYPH65rrrlGp59+upKSkvTll1/q6NGjWrBgwQnPO3HiRGVlZbkue/fubYqnY7qMimH2/t6yWk+yEuWsu6RH0qXTr2mCygAAAODu7GYXgCbSYZC0+wejNdiZ42rctX/5ypU1ezJV5nDKdrI/MgAAAADUWUREhGw2m9LT06tsT09PV5s2bao95tFHH9VNN92k2267TZLUs2dP5eXl6Y477tAjjzwiq/X4z8+Fhoaqa9eu2rFjxwlr8fHxkY+Pzyk8G8+UWRGu1NQS7Fg2/oQGAACAgZUrLcWxQ+1PMnelR3SQAn3syiks1W9pJ24dAAAAAKD+vL291bdvXy1dutS1zeFwaOnSpRo4cGC1x+Tn5x8XoNhsNkmS8wS/5+fm5mrnzp2Kjo5uoMqbj4x8I1wJP9EwewAAAOAECFdainb9jP7A2fulozUPs7TbrOrTIUwSrcEAAACAxjRhwgS98cYbeuedd7R161bdddddysvL07hxxmrzsWPHauLEia79R44cqVdffVXz5s1TcnKylixZokcffVQjR450hSwPPPCAvv/+e+3evVvLly/XqFGjZLPZNGbMGFOeozurXLlSw7wVAAAAoBqsaW4pvAOk6N7S/jVGa7CwDjXuPqBjuJb9fkg/787ULWd3bJoaAQAAgBZm9OjROnTokB577DGlpaWpd+/eWrx4sWvIfUpKSpWVKpMmTZLFYtGkSZO0f/9+RUZGauTIkXrqqadc++zbt09jxozRkSNHFBkZqcGDB2vlypWKjIxs8ufn7jLyjIH24bVtCwYAAACUI1xpSToMKg9XfpJ61/yptX7lc1dWJWfI6XTKYmHuCgAAANAYxo8fr/Hjx1d733fffVfltt1u1+TJkzV58uQTnm/evHkNWV6zlplfOdAeAAAAqAvagrUkHc42vu5ZftJdT28XIm+7VYdzi7T7SH4jFwYAAAAATS+jvC0YK1cAAABQV4QrLUn7AZIsUsZOKSe9xl19vWzq3S5UEnNXAAAAADRPrFwBAABAfRGutCR+YVLUacb1lJOvXunf0WgNtjo5szGrAgAAAABTVIQrrFwBAABAXRGutDQdBhlfa9EarF9FuLKblSsAAAAAmp/M8oH2YYQrAAAAqCPClZamDuFK3w5hslqkvRkFSs0qaOTCAAAAAKBpuWau0BYMAAAAdUS40tJUhCvpm6X8jBp3DfSxKzEmRJK0OrnmfQEAAADAkxQUl6mgpEySFBbgZXI1AAAA8DSEKy1NYGupVRdJTmnvqpPu3i/OaA32827CFQAAAADNR8W8FS+bRYE+dpOrAQAAgKchXGmJXK3BfjrprhVD7X9mqD0AAACAZqSiJViYv7csFovJ1QAAAMDTEK60RB3ONr7WZqh9XJgk6bf0HGWW//EBAAAAAJ6uYuVKOMPsAQAAUA+EKy1RxcqVA+ulotwad20V6KPOrQMlSWv2sHoFAAAAQPNw7MoVAAAAoK4IV1qi0FgppL3kLJP2rT7p7hVzV1YnH2nsygAAAACgSVSszGflCgAAAOqDcKWlcs1dOXlrsAHlc1dW72blCgAAAIDmISO/RJIUFuBlciUAAADwRIQrLVUdwpV+5eHKpv1ZyisqbcyqAAAAAKBJuFau0BYMAAAA9UC40lJVhCv71kglhTXu2jbUT21D/VTmcOqXlKONXxsAAAAANLKM8oH2YbQFAwAAQD0QrrRUrTpLAZFSWZF0YN1Jd+/fkbkrAAAAAJoPZq4AAADgVBCutFQWyzGtwX466e6ucGV3RmNWBQAAAABNIqM8XAmjLRgAAADqgXClJetwtvG1NnNX4oxw5ZeUoyoqLWvMqgAAAACg0WXms3IFAAAA9Ue40pJVrFxJWSWV1TyoPj4yQK0CvFVU6tCm/VlNUBwAAAAANA6n06nMvBJJzFwBAABA/RCutGStEyTfEKkkT0rbUOOuFovFtXplVTKtwQAAAAB4rrziMhWXOSRJ4bQFAwAAQD0QrrRkVpvUfqBxvTatwcrnrvxMuAIAAADAg1UMs/f1ssrP22ZyNQAAAPBEhCstnWuo/YqT7jqgPFxZsydTZQ5nY1YFAAAAAI2mYpg9q1YAAABQX4QrLV3FUPuU5ZLDUeOuPaKDFehjV05hqbalZTdBcQAAAADQ8DLKh9kzbwUAAAD1RbjS0kX3krz8pYJM6dC2Gne1WS3q2yFMEq3BAAAAAHiuirZg4YQrAAAAqCfClZbO5iXF9jeu7/nppLv3L28Ntno34QoAAAAAz1TRFiyMtmAAAACoJ8IVVLYGq8VQe1e4kpwpp5O5KwAAAAA8T2Y+K1cAAABwaghXcMxQ+5+kkwQmp7cLkbfdqsO5RUo+nNcExQEAAABAw8rIK5HEyhUAAADUH+EKpLZ9Ja8AKTdd2r+2xl197Db1jg2VJP1MazAAAAAAHqhy5oqXyZUAAADAUxGuQPLyk7qPMK5v/OCku/ePM1qDrWKoPQAAAAAPlFHeFiyMtmAAAACoJ8IVGHpea3zd9JFUVlrjrv3K566wcgUAAACAJ3KtXKEtGAAAAOqJcAWG+KGSX7iUd0hK/r7GXft2CJPVIu3NKFBqVkETFQgAAAAADSOTlSsAAAA4RYQrMNi8pMRRxvWNH9a4a6CPXYkxIZKk1bQGAwAAAOBBHA6nMvONgfbhhCsAAACoJ8IVVOp5jfF16+dSSc0rUvrTGgwAAACAB8opLFWZwylJCvVnoD0AAADqh3AFlWIHSCHtpeIc6ffFNe7ar3yoPStXAAAAAHiSimH2gT52+dhtJlcDAAAAT0W4gkpWq9TzKuP6SVqD9YsLkyT9np7rGgYJAAAAtARxcXGaMmWKUlJSzC4F9ZCRVzFvhVUrAAAAqD/CFVRV0Rps+9dSQeYJd2sV6KPOrQMl0RoMAAAALct9992nhQsXqlOnTrrwwgs1b948FRUVmV0Waqniw2Hh/sxbAQAAQP0RrqCqqESpdYJUVmzMXqkBc1cAAADQEt13331av369Vq9erR49eujee+9VdHS0xo8fr3Xr1pldHk6ioi1YGMPsAQAAcAoIV3C8nlcbXzd+UONu/Zm7AgAAgBasT58++s9//qMDBw5o8uTJevPNN9WvXz/17t1bM2fOlNPpNLtEVIOVKwAAAGgIhCs43mnl4UryD1L2gRPuVrFyZdOBbOUVlTZFZQAAAIDbKCkp0YIFC3TZZZfpb3/7m84880y9+eabuuqqq/Twww/rhhtuMLtEVIOVKwAAAGgIdrMLgBsK6yDFniXtXSltWigNGl/tbjGhfmob6qf9Rwu0LiVT53SJbOJCAQAAgKa3bt06vf3223r//fdltVo1duxY/fvf/1b37t1d+4waNUr9+vUzsUqciGvlCuEKAAAATgErV1C92rYGq5i7QmswAAAAtBD9+vXT9u3b9eqrr2r//v167rnnqgQrktSxY0ddd911JlWImmTklUiSwmgLBgAAgFNAuILqJY6SLDYpdb10ePsJd6sIV1YRrgAAAKCF2LVrlxYvXqxrrrlGXl5e1e4TEBCgt99+u4krQ21k5lesXKn+ZwcAAADUBuEKqhcQIXW+wLhew+qVfuVD7dfvPaqi0rKmqAwAAAAw1cGDB7Vq1arjtq9atUpr1qwxoSLURUVbMFauAAAA4FQQruDEel5jfN34geR0VrtLfGSAWgV4q6jUoY37spqwOAAAAMAc99xzj/bu3Xvc9v379+uee+4xoSLURUY+M1cAAABw6ghXcGLdRkh2Pyljl3RgXbW7WCwW1+qV1btpDQYAAIDmb8uWLerTp89x28844wxt2bLFhIpQW6VlDmUVlM9cIVwBAADAKSBcwYn5BErdRxjXN354wt0Yag8AAICWxMfHR+np6cdtT01Nld1uN6Ei1FZWQYlrUX6oHzNXAAAAUH+EK6hZRWuwTR9JjupnqlSEK2t2Z6rMUX37MAAAAKC5uOiiizRx4kRlZVW2xT169KgefvhhXXjhhSZWhpOpGGYf4uclu40/hwEAAFB//DaJmsVfIPmFSbnpUvKyanfpER2sQB+7copKtS0tu4kLBAAAAJrWc889p71796pDhw4aOnSohg4dqo4dOyotLU3PP/+82eWhBhl5Rksw5q0AAADgVBGuoGZ2bynhCuP6CVqD2awW9e0QJklaTWswAAAANHNt27bVr7/+qmeeeUYJCQnq27evXnzxRW3cuFGxsbFml4caZOQZK1fC/GkJBgAAgFNDQ2CcXM9rpLVvS1s/ky55XvLyPW6X/h3D9f3vh/Tz7gyNO7ujCUUCAAAATScgIEB33HGH2WWgjiragrFyBQAAAKeKcAUn136gFNxOyt4nbf9aSrjsuF0q5q6sTs6Q0+mUxWJp6ioBAACAJrVlyxalpKSouLi4yvbLLjv+92W4h8qVK4QrAAAAODX1Clf27t0ri8Widu3aSZJWr16tuXPnKiEhgU9vNUdWq9TzKumnF6WNC6oNV05vFyJvu1WHc4uVfDhPnSIDTSgUAAAAaHy7du3SqFGjtHHjRlksFjmdTklyfcCorKzMzPJQg8w8Vq4AAACgYdRr5sr111+v//3vf5KktLQ0XXjhhVq9erUeeeQRTZkypUELhJvoeY3x9fevpYKjx93tY7epd2yoJOauAAAAoHn761//qo4dO+rgwYPy9/fX5s2btWzZMp155pn67rvvzC4PNcgobwsWRrgCAACAU1SvcGXTpk3q37+/JGnBggU67bTTtHz5cs2ZM0ezZs1qyPrgLqJOkyK7S2VF0rYvqt2lf1x5a7DdhCsAAABovlasWKEpU6YoIiJCVqtVVqtVgwcP1tSpU/WXv/zF7PJQA9fKFdqCAQAA4BTVK1wpKSmRj4+PJOmbb75x9RTu3r27UlNTG646uA+LRep5tXF94wfV7nLs3BUAAACguSorK1NQUJAkKSIiQgcOHJAkdejQQb/99puZpeEkMvJLJLFyBQAAAKeuXuFKYmKiZsyYoR9++EFLlizRxRdfLEk6cOCAWrVq1aAFwo2cVh6uJC+TctKOu7tPhzBZLdK+zAKlZhU0cXEAAABA0zjttNO0YcMGSdKAAQP0zDPP6KefftKUKVPUqVMnk6tDTSpnrniZXAkAAAA8Xb3ClX/961967bXXNGTIEI0ZM0a9evWSJH322WeudmFohsI7Su36S06HtGnhcXcH+th1WtsQSaxeAQAAQPM1adIkORwOSdKUKVOUnJysc845R19++aX+85//mFwdalIRroTRFgwAAACnyF6fg4YMGaLDhw8rOztbYWFhru133HGH/P39G6w4uKGe10j7VhutwQbefdzd/eLC9eu+LK1OztDlvduaUCAAAADQuJKSklzXO3furG3btikjI0NhYWGyWCwmVoaaFJc6lFNUKkkKpy0YAAAATlG9Vq4UFBSoqKjIFazs2bNHL7zwgn777Te1bt26QQuEm0m8QrLYpAPrpCM7j7u7Yu7Kzwy1BwAAQDNUUlIiu92uTZs2VdkeHh5OsOLmjuYbq1asFinYl7ZgAAAAODX1Clcuv/xyzZ49W5J09OhRDRgwQM8//7yuuOIKvfrqqw1aINxMYGup0xDj+sYPj7u7X5wRrvyenutacg8AAAA0F15eXmrfvr3KysrMLgV1lJFf2RLMaiUIAwAAwKmpV7iybt06nXPOOZKkDz/8UFFRUdqzZ49mz55Nj+GW4PRrja8bF0hOZ5W7wgO81aV1oCRWrwAAAKB5euSRR/Twww8rI4Pfdz1JRsW8FVqCAQAAoAHUK1zJz89XUFCQJOnrr7/WlVdeKavVqrPOOkt79uxp0ALhhrpfItl9pSM7pNT1x93dr7w1GEPtAQAA0By9/PLLWrZsmWJiYtStWzf16dOnyqWupk+frri4OPn6+mrAgAFavXp1jfu/8MIL6tatm/z8/BQbG6v7779fhYWFp3TOliAzr0SSFM4wewAAADSAeg2079y5sz755BONGjVKX331le6//35J0sGDBxUcHNygBcIN+QRJ3YZLmz82WoPFnFHl7v5x4Zq7KoWVKwAAAGiWrrjiigY71/z58zVhwgTNmPH/7d15dFT1/f/x18xkZrKQlZAFCIR9XwQlBHCpooBWpW64VBRxKaLV0van1CparbjXtlKpFJR+tYK41SqiGAUFQRRE2fdVSEjIPtln7u+PSQYCYUmYzJ0kz8c598zMnXvvvOc6hrl55f35zFRaWppefPFFjRo16oTzWf7nP//Rgw8+qDlz5mjYsGHaunWrbr31VlksFr3wwgsNOmZL4RsWLIL5VgAAAHDmGhSuPPLII7rxxhv1m9/8RhdeeKHS09MlebtYzjrrrFPsjWah37XecGX9O9LFf5KsNt9TNZParz9QKFd5lSKcDfqYAQAAAEFp2rRpfjvWCy+8oDvuuEMTJkyQJM2cOVMfffSR5syZowcffPC47b/++msNHz5cN954oyQpNTVVN9xwg7755psGH1OSysvLVV5e7ntcWFjot/cYLGrmhIxjWDAAAAD4QYOGBbvmmmu0d+9efffdd/rkk0986y+66CL95S9/8VtxCGJdR0qh0VLRQWnP8lpPtY0JU7uYMLk9htbszTOpQAAAACC4VVRUaPXq1Ro5cqRvndVq1ciRI7VixYo69xk2bJhWr17tG+Zr586dWrhwoS699NIGH1OSpk+frujoaN+SkpLij7cYVHxzrjAsGAAAAPygQeGKJCUlJemss87SgQMHtH//fknSkCFD1LNnT78VhyAW4pR6j/Xe//Gt455OY94VAAAANFNWq1U2m+2Ey+nKycmR2+1WYmJirfWJiYnKzMysc58bb7xRf/rTnzRixAjZ7XZ16dJFF1xwgf7whz80+JiSNHXqVBUUFPiWffv2nfb7aCrySuhcAQAAgP80KFzxeDz605/+pOjoaHXs2FEdO3ZUTEyMHn/8cXk8Hn/XiGDV71rv7cYPpKryWk8xqT0AAACaq/fee0/vvvuub5k/f74efPBBJScn65VXXmnU116yZImefPJJ/eMf/9CaNWv07rvv6qOPPtLjjz9+Rsd1Op2KioqqtTQ3dK4AAADAnxo0GcZDDz2k2bNn66mnntLw4cMlScuWLdOjjz6qsrIy/fnPf/ZrkQhSHYdJkW2logPStsVSr5/7nqqZd+X7ffkqr3LLGXL6f8EHAAAABLMrr7zyuHXXXHON+vTpo/nz52vixImndZz4+HjZbDZlZWXVWp+VlaWkpKQ693n44Yd188036/bbb5ck9evXTy6XS3feeaceeuihBh2zpaBzBQAAAP7UoM6VuXPn6l//+pcmTZqk/v37q3///rr77rs1a9Ysvfbaa34uEUHLapP6XuW9v25Brac6x0covpVDFVUerdtfYEJxAAAAQGANHTpUGRkZp729w+HQ4MGDa+3j8XiUkZGh9PT0OvcpKSmR1Vr7Mq5mKDLDMBp0zJYiz1UpSYoJt5tcCQAAAJqDBoUrubm5dc6t0rNnT+Xm1m8YqBkzZig1NVWhoaFKS0vzTcx4Ivn5+Zo8ebKSk5PldDrVvXt3LVy4sF6vCT/qf533dusiqazQt9piseic1OqhwXYzNBgAAACat9LSUv3tb39Tu3bt6rXflClTNGvWLM2dO1ebNm3SpEmT5HK5NGHCBEnS+PHjNXXqVN/2l19+uV5++WXNmzdPu3bt0uLFi/Xwww/r8ssv94UspzpmS1UzLBidKwAAAPCHBg0LNmDAAL300kv629/+Vmv9Sy+9pP79+5/2cebPn68pU6Zo5syZSktL04svvqhRo0Zpy5YtSkhIOG77iooKXXzxxUpISNDbb7+tdu3aac+ePYqJiWnI24A/JPWX4rtLOVulzR9KA2/0PXVOapw+Xp+pVbtydfcF5pUIAAAA+FNsbKwsFovvsWEYKioqUnh4uF5//fV6HWvcuHHKzs7WI488oszMTA0cOFCLFi3yTUi/d+/eWp0qf/zjH2WxWPTHP/5RP/30k9q0aaPLL7+81tDMpzpmS1Ra4VZppVuSFEu4AgAAAD+wGIZh1HenpUuX6rLLLlOHDh18reUrVqzQvn37tHDhQp177rmndZy0tDSdc845eumllyR529VTUlJ077336sEHHzxu+5kzZ+rZZ5/V5s2bZbc3rJW7sLBQ0dHRKigoaJaTNJpi6TPSF3+Wulwo3fyeb/X6nwr0878vU6QzRGunXSKb1XKSgwAAAKCx8B3Yv1577bVa4YrValWbNm2Ulpam2NhYEyvzn+b2mTmQX6phT32uEKtF2/48ptZ/PwAAAKAh338b1Lly/vnna+vWrZoxY4Y2b94sSbrqqqt055136oknnjitcKWiokKrV6+u1eJutVo1cuRIrVixos59PvjgA6Wnp2vy5Mn673//qzZt2ujGG2/UAw884GuBP1Z5ebnKy8t9jwsLC+vcDmeg79XecGXnEqn4kNTK23XUKzlKkc4QFZVXadPBQvVtF21unQAAAIAf3HrrrWaXgHqqGRIsNsJBsAIAAAC/aNCcK5LUtm1b/fnPf9Y777yjd955R0888YTy8vI0e/bs09o/JydHbrf7uNb0xMREZWZm1rnPzp079fbbb8vtdmvhwoV6+OGH9fzzz+uJJ5444etMnz5d0dHRviUlJeX03yROT+suUrvBkuGR1r/rW22zWjSoo/cv975l3hUAAAA0E6+++qoWLFhw3PoFCxZo7ty5JlSEU8krqZ5vJZwhwQAAAOAfDQ5XzODxeJSQkKBXXnlFgwcP1rhx4/TQQw9p5syZJ9xn6tSpKigo8C379u0LYMUtSL/qie3X1b7IHNKpelL7XYQrAAAAaB6mT5+u+Pj449YnJCToySefNKEinMqRzpWGDS8NAAAAHMu0cCU+Pl42m01ZWVm11mdlZSkpKanOfZKTk9W9e/daQ4D16tVLmZmZqqioqHMfp9OpqKioWgsaQZ9fSBar9NN3Uu5O3+qacOXb3blqwPQ+AAAAQNDZu3evOnXqdNz6jh07au/evSZUhFPJqw5X4pjMHgAAAH5iWrjicDg0ePBgZWRk+NZ5PB5lZGQoPT29zn2GDx+u7du3y+Px+NZt3bpVycnJcjj4kmyqyESp0/ne++ve8a3u3z5ajhCrcoortDPHZVJxAAAAgP8kJCToxx9/PG79Dz/8oNatW5tQEU4lt6RSkhTLsGAAAADwk3pNaH/VVVed9Pn8/Px6vfiUKVN0yy236Oyzz9aQIUP04osvyuVyacKECZKk8ePHq127dpo+fbokadKkSXrppZd033336d5779W2bdv05JNP6te//nW9XheNpN+10s4vpHVvSef9TrJY5AyxaWBKjFbtytW3u3LVpU0rs6sEAAAAzsgNN9ygX//614qMjNR5550nSVq6dKnuu+8+XX/99SZXh7rQuQIAAAB/q1e4Eh0dfcrnx48ff9rHGzdunLKzs/XII48oMzNTAwcO1KJFi3yT3O/du1dW65HmmpSUFH3yySf6zW9+o/79+6tdu3a677779MADD9TnbaCx9Lpc+vA3Us5WKfNHKXmAJCmtU5xW7crVql25un5IB5OLBAAAAM7M448/rt27d+uiiy5SSIj3ksrj8Wj8+PHMuRKkcqsntKdzBQAAAP5Sr3Dl1Vdf9XsB99xzj+655546n1uyZMlx69LT07Vy5Uq/1wE/CI2SeoyWNv7XO7F9dbhyTmr1pPa7mdQeAAAATZ/D4dD8+fP1xBNPaO3atQoLC1O/fv3UsWNHs0vDCdC5AgAAAH+rV7gCnFK/a6vDlXekkX+SrFYN6hgrm9Wi/XmlOpBfqrYxYWZXCQAAAJyxbt26qVu3bmaXgdOQWx2uxBKuAAAAwE9Mm9AezVTXiyVntFR0QNr7tSSplTNEfdpGSZK+pXsFAAAATdzVV1+tp59++rj1zzzzjK699loTKsKp5FUPCxbHsGAAAADwE8IV+Jc9VOp9uff+j2/5Vg+pGRpsF+EKAAAAmrYvv/xSl1566XHrx4wZoy+//NKEinAyhmEoz1UpSYqNsJtcDQAAAJoLwhX4X7/rvLcb/ytVlUuSzulEuAIAAIDmobi4WA7H8R0QdrtdhYWFJlSEk3FVuFXh9khizhUAAAD4D+EK/C91hNQqSSrLl7ZnSDoyqf22Q8W+8Y4BAACApqhfv36aP3/+cevnzZun3r17m1ARTqZmMntniFVhdpvJ1QAAAKC5YEJ7+J/VJvW9Wlo5Q1q3QOp5qeIiHOqW0ErbDhXr2925GtUnyewqAQAAgAZ5+OGHddVVV2nHjh268MILJUkZGRn6z3/+o7ffftvk6nCsmj/uiotwyGKxmFwNAAAAmgs6V9A4+l3jvd3ysVReJOnI0GDfMjQYAAAAmrDLL79c77//vrZv3667775bv/3tb/XTTz/p888/V9euXc0uD8fIrZ7MPpbJ7AEAAOBHhCtoHG3Pklp3lapKpc0fSZLSauZd2U24AgAAgKbtsssu0/Lly+VyubRz505dd911+t3vfqcBAwaYXRqOkXdU5woAAADgL4QraBwWi9TvWu/9dQskHZl3ZcOBQhWXV5lVGQAAAOAXX375pW655Ra1bdtWzz//vC688EKtXLnS7LJwjJphwWIJVwAAAOBHhCtoPH2rhwbb8YVUnK22MWFqHxsmt8fQmj155tYGAAAANEBmZqaeeuopdevWTddee62ioqJUXl6u999/X0899ZTOOeccs0vEMfKqhwWLC7ebXAkAAACaE8IVNJ74rt7hwQy3tPF9SdKQ6u6VbxkaDAAAAE3M5Zdfrh49eujHH3/Uiy++qAMHDujvf/+72WXhFHJdlZLoXAEAAIB/Ea6gcdUMDfbjW5KkIdXzrnzDpPYAAABoYj7++GNNnDhRjz32mC677DLZbDazS8JpYM4VAAAANAbCFTSuvldLskj7V0m5u3ROdbiydl++yqvc5tYGAAAA1MOyZctUVFSkwYMHKy0tTS+99JJycnLMLgunkFs9LFhsOOEKAAAA/IdwBY0rMknqdJ73/vp31Dk+QvGtHKqo8mjd/gJzawMAAADqYejQoZo1a5YOHjyou+66S/PmzVPbtm3l8Xi0ePFiFRUVmV0i6kDnCgAAABoD4QoaX83QYOsWyCLpnFSGBgMAAEDTFRERodtuu03Lli3TunXr9Nvf/lZPPfWUEhISdMUVV5hdHo6RR+cKAAAAGgHhChpfr8slm0PK3ixlbfCFK0xqDwAAgKauR48eeuaZZ7R//369+eabZpeDY3g8hvJKvBPa07kCAAAAfyJcQeMLi5G6j/LeX/eWb1L71bvz5PYY5tUFAAAA+InNZtPYsWP1wQcfmF0KjlJUVuW75ogJt5tcDQAAAJoTwhUEhm9osHfUK6mVIp0hKiqv0qaDhebWBQAAAKDZqpnMPsJhU6jdZnI1AAAAaE4IVxAY3S6RnFFS4X7Z9n+jwamxkqRVzLsCAAAAoJH45lthSDAAAAD4GeEKAsMe5p17RZLWLWDeFQAAAACNLs/lDVeYbwUAAAD+RriCwOl3jfd2w3sa2qGVJG/nimEw7woAAAAA/8utDldiwwlXAAAA4F+EKwicTudLEQlSaZ76V6yRI8Sqw64K7cxxmV0ZAAAAgGaoZlgwOlcAAADgb4QrCByrTep7tSTJvuEdnZUSI4l5VwAAAAA0jlxXpSQ6VwAAAOB/hCsIrH7Xem+3LNTwDqGSpG8JVwAAAAA0giNzrthNrgQAAADNDeEKAqvdICm2k1RZoktsayRJ3xCuAAAAAGgEudXDgsUyLBgAAAD8jHAFgWWxSP2vkyR1zfpYNqtFP+WX6kB+qcmFAQAAAGhufJ0rDAsGAAAAPyNcQeD1vUaSFLLzc6UnGZKkb3fTvQIAAADAv+hcAQAAQGMhXEHgtekuJQ+QDLdubPW9JIYGAwAAAOB/R+ZcIVwBAACAfxGuwBzVE9unl3wuiUntAQAAAPiX22Mov7RSkhTLsGAAAADwM8IVmKPv1ZIsis1ZrXbK1rZDxcqt/qsyAAAAADhTBaWVMryjECsm3G5uMQAAAGh2CFdgjqi2UuoISdKE6NWSmHcFAAAAgP/U/PFWVGiI7DYufQEAAOBffMOEeaqHBvu5ZbkkaRVDgwEAAADwk7wS5lsBAABA4yFcgXl6XyFZ7Uoq26Eelr10rgAAAADwm5rOlVjCFQAAADQCwhWYJyxW6naJJOkK29da/1OBisurTC4KAAAAQHOQVx2uxDGZPQAAABoB4QrM1d87NNhV9hUyDI/W7MkzuSAAAAAAzUFuCZ0rAAAAaDyEKzBX99GSo5WSjWwNsmxj3hUAAAAAfuHrXCFcAQAAQCMgXIG57GFSr8slSVfavtYq5l0BAAAA4Ae5rkpJUizDggEAAKAREK7AfP2ukSRdZlup9ftyVF7lNrkgAAAAAE1dXklN54rd5EoAAADQHBGuwHydLpAR0UatLUUa4vlBP+4vMLsiAAAAAE1cbvWwYHSuAAAAoDEQrsB8thBZ+lwlqXpoMOZdAQAAAHCGjnSuEK4AAADA/whXEBz6XStJusT6ndbu+MnkYgAAAAA0db7OFcIVAAAANALCFQSH9merIjJFEZZyxezLkNtjmF0RAAAAgCaq0u1RUVmVJCmOYcEAAADQCAhXEBwsFoUMGCdJusTzlTYdLDS5IAAAAABNVc2QYFaLFBXGhPYAAADwP8IVBA3rgOskSRdYf9APW3aaXA0AAACApirPVSlJigl3yGa1mFwNAAAAmiPCFQSPNj2U3aqH7Ba3tPG/ZlcDAAAAoInyzbcSTtcKAAAAGgfhCoJKWc9fSJJ65nwiw2DeFQAAAAD1VzMsWByT2QMAAKCREK4gqCSk3yhJGqyN2rNzq8nVAAAAAGiKjnSuEK4AAACgcRCuIKg4W3fURkc/SVL+qjdNrgYAAABAU5TnonMFAAAAjYtwBUFnf/ufS5La7P6fyZUAAAAAaIpyq4cFiyVcAQAAQCMhXEHQiRx0lSoMm9qVb5cObTK7HAAAAABNjK9zhWHBAAAA0EgIVxB0+nfrrC+NAZKkwu/mmVwNAAAAgKYmt6RSEp0rAAAAaDyEKwg6Ec4QrY0eKUmyrX9bMgyTKwIAAAAaz4wZM5SamqrQ0FClpaVp1apVJ9z2ggsukMViOW657LLLfNvceuutxz0/evToQLyVoHFkzhW7yZUAAACguSJcQVCq6jpGLsOpiJL90v5vzS4HAAAAaBTz58/XlClTNG3aNK1Zs0YDBgzQqFGjdOjQoTq3f/fdd3Xw4EHfsn79etlsNl177bW1ths9enSt7d58881AvJ2gkVsdrsQyLBgAAAAaCeEKgtKgrm31iecc74NvZ5tbDAAAANBIXnjhBd1xxx2aMGGCevfurZkzZyo8PFxz5sypc/u4uDglJSX5lsWLFys8PPy4cMXpdNbaLjY2NhBvJ2jkldR0rhCuAAAAoHEQriAonZMapzerLvQ++HGetHquuQUBAAAAflZRUaHVq1dr5MiRvnVWq1UjR47UihUrTusYs2fP1vXXX6+IiIha65csWaKEhAT16NFDkyZN0uHDh096nPLychUWFtZamqqySrdKKtySmHMFAAAAjYdwBUEpNsKhgoSz9XzlNd4VH/1W2nN6F5gAAABAU5CTkyO3263ExMRa6xMTE5WZmXnK/VetWqX169fr9ttvr7V+9OjR+ve//62MjAw9/fTTWrp0qcaMGSO3233CY02fPl3R0dG+JSUlpWFvKgjUdK2EWC2KdIaYXA0AAACaK8IVBK1zUuP0d/cvtDHmZ5KnUnrrZil/n9llAQAAAEFh9uzZ6tevn4YMGVJr/fXXX68rrrhC/fr109ixY/Xhhx/q22+/1ZIlS054rKlTp6qgoMC37NvXdL93++ZbiXDIYrGYXA0AAACaK8IVBK0RXeMlWXRX8e3yJPaVXNnSvBulihKzSwMAAADOWHx8vGw2m7Kysmqtz8rKUlJS0kn3dblcmjdvniZOnHjK1+ncubPi4+O1ffv2E27jdDoVFRVVa2mq8lyVkqQ4JrMHAABAIyJcQdC6qFeikqJCta/Yok/6/kUKby1l/ij9d7JkGGaXBwAAAJwRh8OhwYMHKyMjw7fO4/EoIyND6enpJ913wYIFKi8v1y9/+ctTvs7+/ft1+PBhJScnn3HNTUFuSU3nit3kSgAAANCcEa4gaDlCrBo/rKMk6e9rymVc92/JGiJteFda9oLJ1QEAAABnbsqUKZo1a5bmzp2rTZs2adKkSXK5XJowYYIkafz48Zo6depx+82ePVtjx45V69ata60vLi7W73//e61cuVK7d+9WRkaGrrzySnXt2lWjRo0KyHsyW171sGBxTGYPAACARkS4gqB245AOCrPbtPFgoVa6e0mXPut9IuNxacvH5hYHAAAAnKFx48bpueee0yOPPKKBAwdq7dq1WrRokW+S+7179+rgwYO19tmyZYuWLVtW55BgNptNP/74o6644gp1795dEydO1ODBg/XVV1/J6XQG5D2ZzTfnCsOCAQAAoBGFmF0AcDIx4Q5dPbidXl+5V7OX7VL6LbdJmeul72ZL79wh3f6ZlNDT7DIBAACABrvnnnt0zz331PlcXZPQ9+jRQ8YJhskNCwvTJ5984s/ympy8EjpXAAAA0PjoXEHQmzC8kyQpY3OWduW4pDFPSx1HSBVF0pvXSyW5JlcIAAAAIFjQuQIAAIBAIFxB0OvSppUu7Jkgw5BeXb5Lstml6+ZK0R2kvF3S2xMkd5XZZQIAAAAIAnSuAAAAIBAIV9Ak3D7C272y4Lv9KiiplCLipRv+I9nDpZ1LpMUPm1sgAAAAgKCQ66qUJMUSrgAAAKAREa6gSUjv0lo9kyJVWunWm9/u9a5M6if9Yqb3/sp/SN+/YV6BAAAAAIJCXvWwYHEMCwYAAIBGRLiCJsFisWhidffK3K93q9Lt8T7R+0rp/Ae99z+8X9q3ypwCAQAAAJjOMAzlVg8LFhthN7kaAAAANGeEK2gyrhjYVvGtnDpYUKaP12ceeeL8B6SeP5fcFdL8X0oFP5lXJAAAAADTlFS4VVHl/UMs5lwBAABAYyJcQZPhDLHp5qEdJUmzv9opwzC8T1it0i/+KSX0kYqzpHk3SpWlJlYKAAAAwAy51UOCOUOsCrPbTK4GAAAAzRnhCpqUm4Z2kCPEqh/2F2j1nrwjTzhbeSe4D4uTDq6VPrhXqglfAAAAALQIedVDgsVFOGSxWEyuBgAAAM0Z4QqalPhWTl11VjtJ0uxlu2o/GZsqXTdXstikdQuk5X8NfIEAAAAATFPTuRLLZPYAAABoZIQraHJuq57Y/pMNmdqXW1L7yU7nSWOe9t7/7FFp66eBLQ4AAACAaY7uXAEAAAAaE+EKmpzuiZE6t1u8PIb02te7j9/gnNulwbdKMqR3JkrZWwNcIQAAAAAz5LoqJUmxhCsAAABoZIQraJImVnevzP92n4rKKms/abFIY56VOgyTyguleTdIpfmBLxIAAABAQOVVDwsWF243uRIAAAA0d4QraJLO795GXRNaqbi8SvO/3Xf8BiEO6bp/S9Ep0uHt0tu3SR534AsFAAAAEDC51cOC0bkCAACAxka4gibJYrH4ulde+3q33B7j+I1atZGu/48UEibtyJAWPxLgKgEAAAAEkq9zhXAFAAAAjYxwBU3WL85qp7gIh/bnlerTDZl1b5TcXxr7D+/9FS9Ja98MXIEAAAAAAiq3OlyJDSdcAQAAQOMiXEGTFWq36aa0DpKk2ct2nXjDvldJ5/7Oe/9/90n7VwegOgAAAACBlldC5woAAAACg3AFTdrNQzvKbrPouz15Wrsv/8Qb/uwhqcelkrtcmnejVHgwYDUCAAAACIxcV6UkOlcAAADQ+AhX0KQlRIXq8gFtJZ2ie8VqlX7xT6lNL6k4U5p/k1RZFqAqAQAAADQ2wzDoXAEAAEDAEK6gyauZ2H7huoM6kF964g1Do6Qb/iOFxUo/rZY+vF8yjMAUCQAAAKBRFZZVye3xfr+PCbebXA0AAACaO8IVNHl92kYrvXNruT2G5q7YffKN4zpL174mWWzSD29KK2YEokQAAAAAjSyvejL7CIdNoXabydUAAACguQuKcGXGjBlKTU1VaGio0tLStGrVqtPab968ebJYLBo7dmzjFoigV9O98uY3e+Uqrzr5xp0vkEY96b2/+GFp+2eNWxwAAACARpdbPSRYLEOCAQAAIABMD1fmz5+vKVOmaNq0aVqzZo0GDBigUaNG6dChQyfdb/fu3frd736nc889N0CVIphd2DNBneIjVFhWpXfW7D/1Dml3SWf9UjI80oLbpJztjV8kAAAAgEZT07nCfCsAAAAIBNPDlRdeeEF33HGHJkyYoN69e2vmzJkKDw/XnDlzTriP2+3WTTfdpMcee0ydO3cOYLUIVlarRROGp0qS5izbJY/nFHOpWCzSZS9IKWlSeYH05vVSWUHjFwoAAACgUeRWhysx4YQrAAAAaHymhisVFRVavXq1Ro4c6VtntVo1cuRIrVix4oT7/elPf1JCQoImTpx4ytcoLy9XYWFhrQXN09WD2isqNES7D5coY/PJO58kSSFO6br/k6LaSYe3Se/cLnncjV8oAAAAAL/Lqx4WLI7J7AEAABAApoYrOTk5crvdSkxMrLU+MTFRmZmZde6zbNkyzZ49W7NmzTqt15g+fbqio6N9S0pKyhnXjeAU4QzRDWkdJEmzl+08vZ0iE6Xr35BCQqVtn0oZf2rECgEAAAA0llxXpSTmXAEAAEBgmD4sWH0UFRXp5ptv1qxZsxQfH39a+0ydOlUFBQW+Zd++fY1cJcx067BUhVgtWrkzVxsOnOYwX23Pkq6c4b2//EXpxwWNVh8AAACAxuGbc4VhwQAAABAAIWa+eHx8vGw2m7Kysmqtz8rKUlJS0nHb79ixQ7t379bll1/uW+fxeCRJISEh2rJli7p06VJrH6fTKafT2QjVIxglR4fp0n7J+uCHA5q9bJdeuG7g6e3Y7xopa7207C/SB/dIrbtI7QY1aq0AAAAA/Ce3elgwOlcAAAAQCKZ2rjgcDg0ePFgZGRm+dR6PRxkZGUpPTz9u+549e2rdunVau3atb7niiiv0s5/9TGvXrmXIL0iSJo7oJEn63w8HdKiw7PR3vPBhqdsoqapMmneTVFT30HQAAAAAgo+vc4VwBQAAAAFg+rBgU6ZM0axZszR37lxt2rRJkyZNksvl0oQJEyRJ48eP19SpUyVJoaGh6tu3b60lJiZGkZGR6tu3rxwOvkRDGpASo7M7xqrSbejfK/ac/o5Wm3T1LCm+u1R0QJp/s1RV3niFAgAAAPAbX+cKw4IBAAAgAEwPV8aNG6fnnntOjzzyiAYOHKi1a9dq0aJFvknu9+7dq4MHD5pcJZqamu6VN77Zo7JK9+nvGBot3TDPe7t/lfThFMkwGqlKAAAAAP5C5woAAAACydQ5V2rcc889uueee+p8bsmSJSfd97XXXvN/QWjyLumTpPaxYdqfV6p31/ykG9M6nP7OrbtI17wqvXGNtPZ1KamvNHRS4xULAAAA4Iy4PYbySyslSbERdpOrAQAAQEtgeucK0BhsVosmDPd2r8xZvktGfbtPul4kXfKE9/4nD0k7vvBzhQAAAAD8paC00tdwzrBgAAAACATCFTRb153dXq2cIdp+qFhLt2bX/wBD75YG3CgZbmnBrdLhHX6vEQAAAMCZy60eEiwyNER2G5e5AAAAaHx860SzFRlq17hzUiRJs5ftqv8BLBbp53+R2p0tleVLb94glRX6t0gAAAAAZyyvhPlWAAAAEFiEK2jWbh2WKqtF+mpbjrZkFtX/APZQ6fo3pMhkKWeL9O6dksfj/0IBAAAANFhN5wpDggEAACBQCFfQrKXEhWtUnyRJ0pyGdK9IUmSSN2CxOaWtH0tfPOHHCgEAAACcqTwXnSsAAAAILMIVNHu3n+ud2P69tT8pp7i8YQdpN1i68iXv/a+el9a/46fqAAAAAJyp3BI6VwAAABBYhCto9gZ1iNWAlBhVVHn0xsq9DT9Q/+ukYb/23n9/srTubckw/FMkAAAAgAY70rliN7kSAAAAtBSEK2j2LBaLJo7wdq/838rdKqt0N/xgIx+Vul0iVZVK70yU5t0oFR7wT6EAAAAAGiTXVSlJimVYMAAAAAQI4QpahDF9k5QcHaqc4gp98MMZhCFWmzTuDemCP0hWu7RloTRjqLR6Ll0sAAAAgEnyqocFi2NYMAAAAAQI4QpaBLvNqluGpUryTmxvnEkQEuKQLnhAuutL71ws5QXS/34t/ftKKXeXfwoGAAAAcNpyq4cFo3MFAAAAgUK4ghbjhnM6KMxu0+bMIn294/CZHzCxtzRxsXTJE1JImLRrqfTyMGnFPyTPGQw9BgAAAKBefJ0rhCsAAAAIEMIVtBjR4XZdd3Z7SdLsZX7qMLHapGH3SpOWS6nnSpUl0idTpTmjpewt/nkNAAAAACfl61xhWDAAAAAECOEKWpQJwzvJYpE+33xIO7KL/Xfg1l2k8R9IP/+L5IiU9q+SZo6QvnxWclf673UAAAAA1FLp9qiorEoSnSsAAAAIHMIVtCip8RG6qGeiJOnV5X6eH8Vqlc6+TZq8Uup2ieSukD5/QnrlZ9KBtf59LQAAAACSjgwJZrFI0WF2k6sBAABAS0G4ghZn4ohOkqS3V+9XXvXwAX4V3V668S3pqllSWJyUtU6adaH02aNSZZn/Xw8AAABowfJc3k7xmDC7bFaLydUAAACgpSBcQYsztHOceidHqazSo/+s2ts4L2KxSP2vkyavkvr8QjLc0rK/SDOHS3tWNM5rAgAAAC2Qb74VhgQDAABAABGuoMWxWCy+7pV/r9itiipP471YqzbSta9J496QWiVJh7dLr46RFv5eKvfjnC8AAABAC1UzLFgck9kDAAAggAhX0CJdPqCtEiKdyios18J1Bxv/BXv93DsXy1m/lGRIq16R/pEubc9o/NcGAAAAmjE6VwAAAGAGwhW0SI4Qq8and5Qk/WvZThmG0fgvGhYrXTlDuvk9KaaDVLBXev0q6f27pdK8xn99AAAAoBmqmUeRzhUAAAAEEuEKWqwb0zrKGWLV+p8KtWpXbuBeuMuF0qQVUtqvJFmktW9IM9KkTf8LXA0AAABAM5FbQucKAAAAAo9wBS1WXIRDVw1qL0mavWxXYF/c2Uoa87R02yIpvrtUnCXN/6X01i1S8aHA1gIAAAA0YfkllZKkuAi7yZUAAACgJSFcQYs2cUSqJGnxpiztOewKfAEdhkp3fSWd+1vJYpM2vi/NGCL9ME8KxFBlAAAAQBPnm3OFYcEAAAAQQIQraNG6JkTq/O5tZBjSq8t3m1OEPVS66BHpzi+kpH7e+Vfeu0t641qpYL85NQEAAABNRF71sGBxDAsGAACAACJcQYt3+7mdJEkLvtunwrJK8wpJHiDd8YU3aLE5pe2LpRlDpW9nSx6PeXUBAAAAQczXuUK4AgAAgAAiXEGLN6JrvHokRspV4db8VfvMLcZm9w4R9qtlUkqaVFEkfTRFmnu5dHiHubUBAAAAQSivOlyJY1gwAAAABBDhClo8i8Wi26rnXnnt692qcgdBl0ib7tKEj6Uxz0j2CGnPMunlYdLyv0nuKrOrAwAAAIJCWaVbrgq3JDpXAAAAEFiEK4CkKwe2U+sIh37KL9WiDZlml+NltUlpd0l3r5A6XyBVlUmLH5ZmXyxlbTC7OgAAAMB0+SXeYX1tVouiQkNMrgYAAAAtCeEKICnUbtNNQztKkmYv22VyNceI7Sjd/L50xUuSM1o6sEb65/nSF9OlqgqzqwMAAABM45tvJdwhi8VicjUAAABoSQhXgGo3D+0oh82q7/fma83ePLPLqc1ikQbdLE3+Rur5c8lTKS19SnrlfOmn1WZXBwAAgDMwY8YMpaamKjQ0VGlpaVq1atUJt73gggtksViOWy677DLfNoZh6JFHHlFycrLCwsI0cuRIbdu2LRBvJeDySqrnW4mwm1wJAAAAWhrCFaBam0inrhzYVlIQdq/UiEqWxr0uXfOqFB4vHdoo/Wuk9MlDUkWJ2dUBAACgnubPn68pU6Zo2rRpWrNmjQYMGKBRo0bp0KFDdW7/7rvv6uDBg75l/fr1stlsuvbaa33bPPPMM/rb3/6mmTNn6ptvvlFERIRGjRqlsrKyQL2tgDm6cwUAAAAIJMIV4CgTz+0kSfp43UHtzwvSsMJikfpeJU1eJfUfJxkeacVL0szh0tZPmPAeAACgCXnhhRd0xx13aMKECerdu7dmzpyp8PBwzZkzp87t4+LilJSU5FsWL16s8PBwX7hiGIZefPFF/fGPf9SVV16p/v3769///rcOHDig999/P4DvLDCOdK4QrgAAACCwCFeAo/RMitLwrq3lMaS5X+82u5yTi2gtXfWKdONbUlQ7KXen9J/rpOe6Su/fLW1eKFWWml0lAAAATqCiokKrV6/WyJEjfeusVqtGjhypFStWnNYxZs+ereuvv14RERGSpF27dikzM7PWMaOjo5WWlnbSY5aXl6uwsLDW0hT4OlcIVwAAABBghCvAMSaO8HavzFu1T8XlTaALpPso6e6V0tC7pfDWUmmetPYNad4N0jNdpLfGSz8ukMoKzK4UAAAAR8nJyZHb7VZiYmKt9YmJicrMzDzl/qtWrdL69et1++23+9bV7FffY06fPl3R0dG+JSUlpT5vxTR51eFKHMOCAQAAIMAIV4BjXNA9QZ3bRKiovEoLvttndjmnJzRKGj1d+u1W6daPpLRfSVHtpUqXtPG/0ru3e4OW16+WVr8mFdc9hjcAAACajtmzZ6tfv34aMmTIGR9r6tSpKigo8C379jWN78G5JZWS6FwBAABA4BGuAMewWi26bbi3e+XV5bvl9hgmV1QPthApdYQ05mnpN+ulO76Qzv2tFN9D8lRK2z+T/nef9Fx3ac4YacUMKW+P2VUDAAC0SPHx8bLZbMrKyqq1PisrS0lJSSfd1+Vyad68eZo4cWKt9TX71feYTqdTUVFRtZamwNe5EmE3uRIAAAC0NIQrQB2uHtReMeF27c0t0Websk69QzCyWKR2g6SLHpHuWSVN/tZ7v+1Zkgxp79fSJ3+Q/tpfmnmutPQZ6dAmyWhCYRIAAEAT5nA4NHjwYGVkZPjWeTweZWRkKD09/aT7LliwQOXl5frlL39Za32nTp2UlJRU65iFhYX65ptvTnnMpsg35wrDggEAACDACFeAOoQ5bLpxSAdJ0uyvdplcjZ+06e7tYrlziXT/emn001LquZLFKmX+KH3xZ+kfQ6W/D5YWT5P2fyd5PGZXDQAA0KxNmTJFs2bN0ty5c7Vp0yZNmjRJLpdLEyZMkCSNHz9eU6dOPW6/2bNna+zYsWrdunWt9RaLRffff7+eeOIJffDBB1q3bp3Gjx+vtm3bauzYsYF4SwGVV1LTuUK4AgAAgMAKMbsAIFiNT0/VK1/u1KrduVq3v0D92kebXZL/xKRIQ3/lXVw50paPpU3/k3Z+IeXukJa/6F0i20o9L5N6/VzqOFyyMdwCAACAP40bN07Z2dl65JFHlJmZqYEDB2rRokW+Cen37t0rq7X238Rt2bJFy5Yt06efflrnMf/f//t/crlcuvPOO5Wfn68RI0Zo0aJFCg0NbfT3E0iGYdC5AgAAANNYDKNljQFUWFio6OhoFRQUNJlxhGGe++d9r/fXHtDYgW314vVnmV1O4ysrlLYvljZ9KG37VKooPvJcWKzUfYzU63Kpy88ke5h5dQIAgHrhOzDqqyl8ZkoqqtT7kU8kSRseG6UIJ387CAAAgIZpyPdfhgUDTmLiiM6SpA9/PKjMgjKTqwmA0Cip79XSta9Kv98h3fiWdNbNUnhrqTRP+uE/0rwbpGe6SG+Nl35cIJUVmF01AAAAWqCarhVHiFXhDpvJ1QAAAKCl4U97gJPo1z5aQzrFadWuXP17xW79v9E9zS4pcOyhUvdR3sVdJe1b6R06bNOHUuF+aeN/vYvVLnU+X+r5c+8QYq0SAl+rx+0NeUrzpLL86vv53vul1Y9996tvLRap7zXSoJul0GY05BsAAEALkeeqlCTFhTtksVhMrgYAAAAtDeEKcAoTR3TSql25euObvbrnwq4Kd7TA/21sIVLqCO8y+inpwPfS5g+9YUvOVmn7Z97lw99IHYZ6hw7r+XMptuPpv0ZV+emFIseGJ2UFUnlhw97Xge+lJU9JZ/1SSrtLiuvUsOMAAAAg4HKrJ7OPZTJ7AAAAmKAF/pYYqJ+RvRLVIS5ce3NL9M6an3Tz0HoEBs2RxSK1G+RdLnpEyt7iDVk2f+gNK/au8C6f/EFK6ucNWUKjTx6QlOZLVaVnXps9QgqLkUJjvK9Zcz+s+rHvfoxU+JP0zT+lnC3SNy9L38z0dt4MvVvqOMz7PgEAABC08qqHBYuLsJtcCQAAAFoiwhXgFGxWiyYMT9Vj/9uoV5ft0k1DOshq5RfvPm16eJfzfifl75M2f+QNWvYslzLXeZf6cEZLYdEnDkV84UlM7SAlNFoKqedfLQ6eIO34XFr5D2lHhrfuzR9KyQO8IUufq+p/TAAAAAREzZwrseF8XwMAAEDgEa4Ap+Has1P0wqdbtTPHpSVbD+nCnolmlxScYlKkob/yLq4cacvH3tBCljo6SWKOX+eMkqwBnIzUapW6jfQuhzZ7Q5Yf50sHf5Deu0taPE0acrs0+DYponXg6gIAAMAp5ZXUdK4QrgAAACDwCFeA09DKGaLrh6Ro1le7NHvZLsKV0xER750sftDNZldyehJ6Slf8TbpomrR6jrTqX1JxpvT5E9KXz0n9x3m7WRJ6ml0pAAAAROcKAAAAzGU1uwCgqbhlWKpsVouWbz+sTQcbOIE6gl9Ea+m830v3r5N+8Yp3iLCqMmnNXOkfadL/XSVt/0wyDLMrBQAAaNHoXAEAAICZCFeA09Q+Nlyj+yZJkmYv22VyNWh0IQ5pwDjpzqXSrQulnj+XZPEOc/b61dKMNOm7V6XKUrMrBQAAaJF8nSuEKwAAADAB4QpQDxNHdJIkfbD2gA4VlplcDQLCYpFSh0vXvyH9+nspbZLkaCXlbJE+vF96obeU8Sep8KDZlQIAALQoea5KSVIcw4IBAADABIQrQD0M6hCrQR1iVOH26NfzvldFlcfskhBIcZ2kMU9JUzZKo56UYjpIpbnSV89LL/aT3r1TOrDW7CoBAABahNySms4Vu8mVAAAAoCUiXAHq6cmr+qmVM0Qrd+bqD++tk8HcGy1PaLSUPlm693vpuv+TOqRLnkrpx/nSK+dLr14qbfqf5HGbXSkAAECzZBiG8lzMuQIAAADzEK4A9dQzKUp/v/EsWS3S26v36x9LdphdEsxiC5F6XyHdtki64wup37WSNUTas1ya/0vp74OklS9LZYVmVwoAANCsFJVXqcrj/SOnWIYFAwAAgAkIV4AG+FmPBD12RR9J0rOfbNH/fjhgckUwXbtB0tX/ku5fJ42YIoXFSnm7pUUPSn/pIy36g/cx/KOyTCrKNLsKAABgkpqulXCHTaF2m8nVAAAAoCUKMbsAoKm6OT1Vu3JKNGf5Lv12wQ9qGxOmwR1jzS4LZotqK42cJp33e+nHed7OlZyt0soZ0jcvSz0vk4ZOljoMlSwWs6ttGkpypcx1UuaP3tuDP3rPqeGWUoZKw+6RelwqWfnFCgAALUVudbhC1woAAADMQrgCnIGHLuulvbkl+mxTlu7893d67+7h6tA63OyyEAwc4dLZt0mDbpV2ZEgr/yHt+Nw7F8um/0ltz/KGLH3GSjYmYZUkGYZUsO9IgFITphTsO/E++1ZK81dKsZ2koXdLA2+UnK0CVzMAADBFXgnzrQAAAMBcFqOFzcZdWFio6OhoFRQUKCoqyuxy0Ay4yqt03T9XaMOBQnVpE6F37x6u6DB+WY46HNrkDVl+mC+5y73rIpOlIXdIgydI4XHm1hdI7ipv94mvG+UH721Zft3bx3SUkvtLSTVLP2+nyqpXpG9nH9kvNNobag2509tFBACQxHdg1F+wf2beXr1fv1vwg87r3kb/vm2I2eUAAACgiWvI91/CFcAPMgvKNHbGcmUWlml419Z6bcIQ2W1MaYQTcOVI370qfTtLKs7yrgsJkwZcL/W/TopMkiLaSI5WzWPosPJiKWtDdZBSHaZkbTwSMB3NGiK16eUNT5KrQ5TEvlJYzImPX+GS1v7HG1zl7jxynL7XSOmTvccBgBaO78Cor2D/zMz6cqf+vHCTxg5sqxevP8vscgAAANDEEa6chmC/SEDTteFAga6duUIlFW6NOztFT13dT5bm8ItxNJ6qcmn9u975WDLXHf98SKg3ZImIr749yf3weCkkCIbFKD7kDVAO/nhknpTDOyTV8U+NI1JK6nukEyW5v9SmpxTibNhrezzS1o+lFTOkPcuPrO90npR+j9T1YslK6AmgZeI7MOor2D8zTy/arJeX7NCE4amadnkfs8sBAABAE9eQ77/MuQL4SZ+20XrpxrN0+9zvNP+7fUqNj9CkC7qYXRaCWYhTGniDt2Nlz3Lpm5ne4bGKs6WqUqmqzDvfyMnmHDlaaHTt4CX8RKFMGyks9syCBo9HyttVe5L5zHVScWbd27dKOtKJUhOmxHbyb9hhtUo9L/MuP63xhiwb3pN2feld4rt752UZcL1kD/Pf6wIAgIDLq57QPo4J7QEAAGASwhXAjy7smaiHf95bj/1vo55etFkdW4fr0n7JZpeFYGexSKkjvEuNCpfkyvYOIVbn7TH3DbdUVuBdDm8/jde0SeGtT9EZU/04LFbK232kEyVznZS5XqooquvAUuuutYf1SuovtUrw19k6Pe0GSdfMli5+zBtarZ7rnePlw/ulzx+XzrnduwS6LgAA4Be51eFKLBPaAwAAwCSEK4CfTRjeSbtzXJq7Yo9+M3+t2saEaWBKjNlloalxRHiX2NRTb+vxeCd0rxW8nCSIKcv3hjGuQ96loWxOKbH3UcN6DZASekvOVg0/pr9Ft5cueUI6/wFpzf9JK1+WCvZKS5+Wlr3oneMmfbKU0MvsSgEAQD3klVR3rhCuAAAAwCSEK0AjePjnvbU3t0RfbMnW7XO/0/uTh6l9bLjZZaG5slql8Djv0qb7qbd3V0olh08QwhzzuGaIstCY6k6U/kfClPjukq2J/DPijJTS75aG3Clt/p/09UvST99J3/+fd+k60huydP6Zt5MIAAAENV/nCsOCAQAAwCRN5LdiQNMSYrPq7zcO0rUzV2jTwULd9tq3envSMEWF2s0uDZBsdikyybucjspSKSS0eYQOthCpzy+8y95vpBUvSZs/lLZ/5l0S+nhDln7XeOfEAQAAQSmvpFISnSsAAAAwjx9nEgZwtFbOEM259WwlRDq1NatYk99Yo0q3x+yygPqzhzWPYOVYHdKkcf8n3btGSvuVZI+QDm2Q/nu39GI/6ctnpZJcs6sEAADHcHsM5ZfUzLnCHy8BAADAHIQrQCNKjg7T7FvOUZjdpq+25WjaBxtkGIbZZQE4WlwnaczT0pQN0sjHpMi2UnGW9PkT0gu9pY9+Kx3eYXaVDefxSMWHpLJCiZ8/AIBmoLC0Up7qf9IYFgwAAABmYVgwoJH1ax+tv14/UHe9vlr/+WavOrWO0B3ndTa7LADHCouVRtwvDb1b2vi+9PXfpcwfpW//JX07W+oxRkq/R+o4LLg6eQzD22GTv1vK3yvl7ZHy9xy5X7BPqirzbmsPl1olSK2Sqm8TpchE7+3RS0SbpjOfDgCgxcmt7lqJDA2R3cbfCwIAAMAc/OYECIBL+iTpoUt76YmPNunJjzepQ+twjepzmvNdAAisEIfU/zqp37XS7mXeeVm2LpK2LPQubc/yhiy9r/TOXxMIZQV1Byc19yuKT+84lSVS3m7vclIWKSK+Omw5URhTvc4ZGVxhEwCg2curnsye+VYAAABgJsIVIEAmjuik3Ydden3lXt0373u9dVe6+rePMbssACdisUidzvUuOdukFTOkH96UDnwvvTNRWjxNSrtLGnyLFBp9Zq9VUeINSXzBye7aIUpZ/qmP0SpJiu0oxXSUYjrUvh/dXqoql1yHpKIs77BnxYek4swj94syvbeuQ5LhkVzZ3iXrFK8bEnZU4FITxFTfjzwqlIlI8H83jMcjucu9762qvPp+hbdT5+j1vufquF/X4xCn97zFdDhyDiPiCZEAIEjkVocrDAkGAAAAMxGuAAFisVj06OV9tC+3VEu3Zmvi3O/0/uThahcTZnZpAE4lvpt0+YvShQ9L382WVr0iFe6XFj8sLX1aGjTeG7TEpta9f1W5VLC/OjSpDlHy9hy578o+dQ3hresITjp670enSPbQk+9vs0vOVlLcKYYl9LilksPe0MUXxBy9HBXEVBRJVaWn3w0T3rp290tYnOSpOiYUqb6tMxSpea761lN56vPmL/bwowKXY4KXmI5SeBzhCwAESF4JnSsAAAAwn8VoYbNrFxYWKjo6WgUFBYqKijK7HLRARWWVunbmCm3OLFLPpEgt+FW6IkMDNLQQAP+oLJPWLfB2s2Rv8q6zWKVeV0hdLvQGKUeHKEUHJZ3in1tntBTboXZocvQv8J2tGv1t1VuF66gumKPDmMza62q6YRqVxdtxEuKUbE4pJNQ7xJvNeWS977ljH1dvGxIq2Rze4dPy9x5ZCg/olP/9HK3qCF+O+u8XFtv0wxePRyov8A5TV5rvva0ql1p38QaLVpvZFeIk+A6M+grmz8zLS3bo6UWbdfWg9nr+ugFmlwMAAIBmoCHff+lcAQIsMtSu2beeoytfWq7NmUW6983v9a/xZyuEyTiBpsMeKg26WTrrl9KODG/IsuNzaeP73qXOfcLrHrIr9qhfvjc1jghvJ8xpdcPkHj8MWWmet6OmJtSoMxA55rlaj48KSGz2xgsvajqPfIHLntrhS9FB77w3hzZ6l7o4Imv/9z4ufIlpnNqPVVlaOxwpy6/jcX4dzxdI5YU6YcgUEiYl9JQS+0gJfaTE3lJiX+9wagDgZ0c6V/gDJQAAAJiHcAUwQbuYMM2+5WyNe2WFlmzJ1p8+3KjHrugjS1P/q2agpbFYpK4jvUvWBu9wYfn7jvziPLajFJPKnB1Wm9SqjXdRP7Orqb8Qp7c7o3WXup+vLKsOX/bUHb4UZ3mHUDu0wbvUxRl9zOfmmAAmtPqvZjxub8hx0nDkJI/d5X44H2HeeYbCYiRriHR4u3d4uAPfe5ejRSR4A5fEPlJCb+9tmx6SnSExATScb84VhgUDAACAiQhXAJMMSInRi+MGatIba/TvFXuU2jpCt43oZHZZABoqsY90+V/NrgJmsIdK8V29S10qS72hW/5eKX937eAlb49UkuMdbitrnXepS2i0t2mkvODM67VYJWeUNxwJjZZCY46EJbUex9b9fIiz9vE8bil3pzdgPLTRe5u1wTsPj+uQtPOQtPOL2q8f1+X40CWmo2Rtpl2cVeXejq2q8hN/TgCctrzqcCWOCe0BAABgIsIVwESj+ybrwdE9Nf3jzXr8o43qEBeukb0TzS4LAOBP9jCpTXfvUpcK11Hhy57anS95e6TSXG/XSa1jhp8iGDnm8dHrHJH+DTGsNim+m3fpM/bI+vJiKXvz8aFLaa50eJt3OXoYPXuElNDr+NAlPM5/tfqTu8objBVnScXZ1bfVw965Dh2Zd6g468h/v6T+0q++MrduoBnILaFzBQAAAOYjXAFMdud5nbX7sEtvrtqnX8/7Xm/dla6+7aLNLgsAECiOCO98JQk9636+vMg77Jg1pDosiTq+eyQYOVtJ7c/2LjUMwxs21AQtNaFL9map0iX99J13OVpk8pGgpSZ0adOjcc6BYXjnAjo6KPGFJNW3ruogxZWjE85BUxer3du1A+CM+TpXCFcAAABgIsIVwGQWi0V/urKv9ueV6qttOZo491u9P3m4kqMZjx4AIMkZ6e3oaA4sFikyybt0vejIeneVlLvj+NAlf49UdNC77Mg46jjV3TJHhy6JfaTolOPnNjIMb0DlOqa7pK7wxJUteSrr8X6sUkQb79wyrRKkVonH3B51PzSm5c67BPiZb84VhgUDAACAiQhXgCBgt1k146ZBuvofX2vboWJNfO07LfhVuiKc/C8KAGgBbCHebpQ2PaS+Vx1ZX14kHdp0fOhSlu/tdsneLG1498j2zihvEBUef1SYckiqKq1fPWGxtYOS48KT6vvhrb3DogEImEq3R4VlVZLoXAEAAIC5+M0tECSiQu2ac+s5+sU/lmvjwUL9+s3v9cr4s2Wz8leuAIAWyhkppQzxLjUMQyo8UHsel0MbpewtUnmhtO+buo/liDwqGEk4cXgS0UYK4Re2QLDKL/F2l1ksUnSY3eRqAAAA0JIRrgBBJCUuXLPGn63rX1mpjM2H9PiHG/XoFX3MLgsAgOBhsUjR7bxLt4uPrHdXSjnbvEFLWX51eFIdlrRK8M5tA6DJy6uezD4mzM4fIQEAAMBUhCtAkDmrQ6z+Mm6g7n5jjV77erc6xUfolmGpZpcFAEBws9mlxN7eBUCz5ZtvhSHBAAAAYDKr2QUAON6l/ZL1/0b3kCQ99r8N+nxzlskVAQAAAObLqw5X4pjMHgAAACYLinBlxowZSk1NVWhoqNLS0rRq1aoTbjtr1iyde+65io2NVWxsrEaOHHnS7YGmatL5XXTd2e3lMaR7//O9Nh4oNLskAAAAwFS5JXSuAAAAIDiYHq7Mnz9fU6ZM0bRp07RmzRoNGDBAo0aN0qFDh+rcfsmSJbrhhhv0xRdfaMWKFUpJSdEll1yin376KcCVA43LYrHoibH9lN65tVwVbk2c+62yCsvMLgsAAAAwDZ0rAAAACBamhysvvPCC7rjjDk2YMEG9e/fWzJkzFR4erjlz5tS5/RtvvKG7775bAwcOVM+ePfWvf/1LHo9HGRkZAa4caHyOEKtm/nKwurSJ0MGCMk2c+61KKqrMLgsAAAAwRa6rUhKdKwAAADCfqeFKRUWFVq9erZEjR/rWWa1WjRw5UitWrDitY5SUlKiyslJxcXF1Pl9eXq7CwsJaC9CURIfb9eqtQxQX4dD6nwp137y1cnsMs8sCAAAAAi6veliwuAi7yZUAAACgpTM1XMnJyZHb7VZiYmKt9YmJicrMzDytYzzwwANq27ZtrYDmaNOnT1d0dLRvSUlJOeO6gUDr0Dpcs8YPliPEqsUbszR94SazSwIAAAACLrd6WLBYhgUDAACAyUwfFuxMPPXUU5o3b57ee+89hYaG1rnN1KlTVVBQ4Fv27dsX4CoB/xjcMU7PXTtAkvSvZbv0+so9JlcEAAAABNaRzhXCFQAAAJgrxMwXj4+Pl81mU1ZWVq31WVlZSkpKOum+zz33nJ566il99tln6t+//wm3czqdcjqdfqkXMNsVA9pqT45Lzy/eqmkfbFBKXLjO797G7LIAAACAgKjpXImhcwUAAAAmM7VzxeFwaPDgwbUmo6+ZnD49Pf2E+z3zzDN6/PHHtWjRIp199tmBKBUIGvdc2FVXD2ovt8fQ5DfWaHMm8wgBAACgZchz0bkCAACA4GD6sGBTpkzRrFmzNHfuXG3atEmTJk2Sy+XShAkTJEnjx4/X1KlTfds//fTTevjhhzVnzhylpqYqMzNTmZmZKi4uNustAAFlsVg0/ap+SusUp+LyKk187TsdKiozuywAAACgUZVVuuWqcEuS4uhcAQAAgMlMD1fGjRun5557To888ogGDhyotWvXatGiRb5J7vfu3auDBw/6tn/55ZdVUVGha665RsnJyb7lueeeM+stAAHnCLHqnzcPVuf4CP2UX6o75n6n0uoLTQAAAKA5yi+plCTZrBZFhpo6wjUAAAAgi2EYhtlFBFJhYaGio6NVUFCgqKgos8sBzsjuHJd+8Y/lyiup1Og+SfrHTYNktVrMLgsAAAQZvgOjvoLxM7PxQKEu/dtXim/l0Hd/vNjscgAAANCMNOT7r+mdKwAaLjU+Qq+MP1sOm1WLNmTqTx9uVKXbY3ZZAAAAgN/llXjnW4llSDAAAAAEAcIVoIk7JzVOz1zTX5L02te79fO/LdPKnYdNrgoAAADwr9zqyexjmcweAAAAQYBwBWgGxp7VTi9cN0Cx4XZtySrS9a+s1K/f/F5ZhUx0DwAAgOahpnOFyewBAAAQDAhXgGbiqkHt9flvL9BNaR1ksUgf/HBAFz63RP9cukMVVQwVBgAAgKaNzhUAAAAEE8IVoBmJjXDoz7/opw8mj9DAlBi5Ktya/vFmjfnrl1q+Pcfs8gAAAIAGy6sOV+Ii7CZXAgAAABCuAM1Sv/bRenfSMD1zTX+1jnBoR7ZLN/3rG01+Y40O5JeaXR4AAABQb7kllZKY0B4AAADBgXAFaKasVouuOztFn//2At2S3lFWi/TRuoO66PmlmvHFdpVXuc0uEQAAADhtRzpXCFcAAABgPsIVoJmLDrfrsSv76sN7z9U5qbEqrXTr2U+2aPSLX2np1myzywMAAGjxZsyYodTUVIWGhiotLU2rVq066fb5+fmaPHmykpOT5XQ61b17dy1cuND3/KOPPiqLxVJr6dmzZ2O/jUbHnCsAAAAIJiFmFwAgMHq3jdJbd6Xrve9/0pMLN2tXjku3zFmlS3on6uGf91ZKXLjZJQIAALQ48+fP15QpUzRz5kylpaXpxRdf1KhRo7RlyxYlJCQct31FRYUuvvhiJSQk6O2331a7du20Z88excTE1NquT58++uyzz3yPQ0Ka/qVfXkl15wrDggEAACAINP1v2ABOm8Vi0VWD2mtk70S9uHib5q7YrU83Zmnp1mxN/llX3XleZ4XabWaXCQAA0GK88MILuuOOOzRhwgRJ0syZM/XRRx9pzpw5evDBB4/bfs6cOcrNzdXXX38tu907sXtqaupx24WEhCgpKalRaw8kwzB8nSsMCwYAAIBgwLBgQAsUFWrXI5f31sJfn6u0TnEqr/LohcVbNerFL/X55iyzywMAAGgRKioqtHr1ao0cOdK3zmq1auTIkVqxYkWd+3zwwQdKT0/X5MmTlZiYqL59++rJJ5+U2117Pr1t27apbdu26ty5s2666Sbt3bv3pLWUl5ersLCw1hJMSivdKq/ySGJYMAAAAAQHwhWgBeuRFKl5dw7VX68fqMQop/YcLtFtr32nia99q72HS8wuDwAAoFnLycmR2+1WYmJirfWJiYnKzMysc5+dO3fq7bffltvt1sKFC/Xwww/r+eef1xNPPOHbJi0tTa+99poWLVqkl19+Wbt27dK5556roqKiE9Yyffp0RUdH+5aUlBT/vEk/qelacdisinDQaQ0AAADzEa4ALZzFYtGVA9sp47cX6K7zOivEalHG5kMa+ZelemHxVpVVuk99EAAAAASEx+NRQkKCXnnlFQ0ePFjjxo3TQw89pJkzZ/q2GTNmjK699lr1799fo0aN0sKFC5Wfn6+33nrrhMedOnWqCgoKfMu+ffsC8XZOW56rUpIUG2GXxWIxuRoAAACAcAVAtVbOEE29tJcW3X+uhndtrYoqj/6WsU0jX1iqTzZkyjAMs0sEAABoVuLj42Wz2ZSVVXtY1qysrBPOl5KcnKzu3bvLZjvSvdGrVy9lZmaqoqKizn1iYmLUvXt3bd++/YS1OJ1ORUVF1VqCSW71ZPaxTGYPAACAIEG4AqCWrgmRen1immbcOEjJ0aHan1equ/5vtW599VvtynGZXR4AAECz4XA4NHjwYGVkZPjWeTweZWRkKD09vc59hg8fru3bt8vj8fjWbd26VcnJyXI46g4eiouLtWPHDiUnJ/v3DQRQHpPZAwAAIMgQrgA4jsVi0WX9k5Xx2/N19wVdZLdZtHRrtkb95Us9+8lmlVRUmV0iAABAszBlyhTNmjVLc+fO1aZNmzRp0iS5XC5NmDBBkjR+/HhNnTrVt/2kSZOUm5ur++67T1u3btVHH32kJ598UpMnT/Zt87vf/U5Lly7V7t279fXXX+sXv/iFbDabbrjhhoC/P3+pmXOFyewBAAAQLELMLgBA8Ap3hOj/je6pawa316P/26gvt2Zrxhc79N6an/THn/fWmL5JjHkNAABwBsaNG6fs7Gw98sgjyszM1MCBA7Vo0SLfJPd79+6V1Xrkb+JSUlL0ySef6De/+Y369++vdu3a6b777tMDDzzg22b//v264YYbdPjwYbVp00YjRozQypUr1aZNm4C/P3/Jqx4WLI5hwQAAABAkLEYLm0ihsLBQ0dHRKigoCLpxhIFgZhiGPt2YpT/9b6N+yi+VJI3oGq9Hr+ijrgmtTK4OAACcDN+BUV/B9pl56L11euObvfr1Rd005eLuZpcDAACAZqYh338ZFgzAabFYLBrVJ0mfTTlfv76omxwhVi3bnqPRL36p6Qs3qbicocIAAADQOI50rthNrgQAAADwIlwBUC9hDpumXNxdi39zni7qmaAqj6F/frlTFz2/RB/8cEAtrBkOAAAAAcCcKwAAAAg2hCsAGqRj6wjNvvUczb7lbHWIC1dWYbl+/eb3unHWN9qaVWR2eQAAAGhG8lyVkqQ4whUAAAAECcIVAGfkol6J+vQ352nKxd3lDLFqxc7DGvPXr/T4hxtVVFZpdnkAAABoBnKrhwWLZUJ7AAAABAnCFQBnLNRu068v6qbPppyvS3onyu0xNHvZLl34/FK99/1+hgoDAABAgxmGobzqYcHoXAEAAECwIFwB4DcpceF6ZfzZem3COeoUH6HsonL9Zv4POveZL/Sn/23Uyp2HVeX2mF0mAAAAmpDi8ipVebx/rEPnCgAAAIJFiNkFAGh+LuiRoPQurfWvr3bpH19s1/68Us1Zvktzlu9SbLhdF/VK1MW9E3VetzYKc9jMLhcAAABBrGa+lTC7je+OAAAACBqEKwAahTPEpsk/66rbhnfSV9uy9enGLGVsylJeSaXeXr1fb6/er1C7Ved2a6NLeifqol6JDPMAAACA49TMt8J3RQAAAAQTwhUAjSrMYdMlfZJ0SZ8kVbk9+m5Pnj7dkKVPN2Zqf16pFm/M0uKNWbJapCGd4nRJ7yRd3DtRKXHhZpcOAACAIFAz30pshN3kSgAAAIAjCFcABEyIzaqhnVtraOfWevjnvbTpYJE+3ZipTzdkaePBQq3cmauVO3P1pw83qldylC7pnahL+iSqd3KULBaL2eUDAADABLk14QrzrQAAACCIEK4AMIXFYlHvtlHq3TZK94/srn25JVq80dvRsmpXrjYdLNSmg4X6a8Y2tYsJ0yV9EnVJ7ySdkxqrEJvV7PIBAAAQIHkMCwYAAIAgRLgCICikxIXrthGddNuITspzVShj8yF9uiFTX27L1k/5pXp1+W69uny3YsLtuqint6PlvG5tmNQUAACgmaNzBQAAAMGIcAVA0ImNcOiawe11zeD2Kq1w66tt2fp0Y5YyNmUpr6RS76zZr3fW7Feo3apzu7XRJb0TdVGvRP6aEQAAoBmicwUAAADBiHAFQFALc9h0SZ8kXdInSVVuj77bk6dPN3iHD9ufV6rFG7O0eGOWrBbpnNQ477a9E5USF2526QAAAPADX+cK4QoAAACCCOEKgCYjxGbV0M6tNbRzaz38817adLBIn27M1KcbsrTxYKG+2ZWrb3bl6vEPN6pXcpQu6e0dPqx3cpQsFovZ5QMAAKAB8lyVkqQ4hgUDAABAECFcAdAkWSwW9W4bpd5to3T/yO7al1uixRu9HS2rduVq08FCbTpYqL9mbFO7mDBd0idRl/RO0jmpsQqxWc0uHwAAAKcpt6Smc8VuciUAAADAEYQrAJqFlLhw3Taik24b0Ul5rgplbD6kTzdk6stt2fopv1SvLt+tV5fvVky4XRf1TNTFvRM1olu8Wjn5MQgAABDM8lzMuQIAAIDgw28VATQ7sREOXTO4va4Z3F6lFW59tS1bn27MUsamLOWVVOqdNfv1zpr9stssGtwxVud3T9D53duoV3Ikw4cBAAAEEY/HODKhPcOCAQAAIIgQrgBo1sIcNu8k932SVOX26Ls9efp0Q5YyNmdpz+ESrdyZq5U7c/X0os1qE+nU+d3b6LzubXRu13gmTQUAADBZYVmlPIb3fgzhCgAAAIII4QqAFiPEZtXQzq01tHNrPXJ5b+3OcenLbdlauiVbX+84rOyicr29er/eXr1fFos0oH2Mzu/eRuf3aKMB7WNks9LVAgAAEEi51UOCRTpD5Ahh3jwAAAAED8IVAC1WanyEUuMjND49VeVVbq3enaelW7O1dGu2NmcWae2+fK3dl6+/ZmxTdJhd53aL13nd2+j87m2UGBVqdvkAAADNXp5vMnu6VgAAABBcCFcAQJIzxKZhXeM1rGu8pl7aSwcLSvXV1hwt3Zqtr7Zlq6C0Uh/+eFAf/nhQktQzKVLn9/AGLWd3jOMvKQEAABpBrqtSEuEKAAAAgg/hCgDUITk6TNedk6LrzklRldujH/bna+mWbC3dlqMf9+drc2aRNmcW6Z9LdyrcYdOwLvE6v3u8zu+eoA6tw80uHwAAoFnIc9VMZm83uRIAAACgNsIVADiFEJtVgzvGaXDHOE25pIdyXRX6apt3+LAvt+Yop7hcn23K0mebsiRtUKf4CO9cLd3baGjn1gpz2Mx+CwAAAE1SLsOCAQAAIEgRrgBAPcVFOHTlwHa6cmA7eTyGNh4srA5asrV6T5525bi0K8el177eLUeIVWmd4nRetzY6v0cbdUtoJYvFYvZbAAAAaBKOdK4QrgAAACC4EK4AwBmwWi3q2y5afdtFa/LPuqqorFJf7zispVuztXRLtn7KL9VX23L01bYc/XnhJiVHh/q6WoZ1jVd0GENcAAAAnEiui84VAAAABCfCFQDwo8hQu0b1SdKoPkkyDEM7sl3eoGVrtr7ZeVgHC8o079t9mvftPtmsFg3qEOPraunbNlpWK10tAAAANfKqhwWLI1wBAABAkCFcAYBGYrFY1DWhlbomtNLEEZ1UVunWN7tytXRLtpZuPaQd2S59uztP3+7O0/OLt6p1hENDOsWpZ1KUeiRFqldypFJiwwlcAABAi+XrXGFYMAAAAAQZwhUACJBQu803JJjUW/tyS/TlNu/wYV/vOKzDrgp9vD5TH6/P9O0T7rCpW2KkeiZGqkdSpHomeW9bt3Ka90YAAAACJK+kUhKdKwAAAAg+hCsAYJKUuHDdlNZRN6V1VKXbozV78vTD/nxtzizSlswibTtUrJIKt37Yl68f9uXX2je+ldMXtNSELt0SIhXmsJnzZgAAABpBTedKXATz1AEAACC4EK4AQBCw26xK69xaaZ1b+9ZVuT3afbhEWzKLtCWz0Bu6ZBVpb26JcorLtWx7uZZtz/Ftb7FIqa0j1OOYLpeOrSNkY2gxAADQxFS5PSoo9XauMCwYAAAAgg3hCgAEqRCb1Tdny2X9k33rSyqqtDWr+EjgUr0cdlVoV45Lu3JcWrThyNBioXaruiXUDlx6JEWqTSunLBZCFwAAEJzyq4MVi0WKDqNzBQAAAMGFcAUAmphwR4gGpsRoYEpMrfXZReXaklmkzZmF3sAlq0hbs4pUVunRup8KtO6nglrbx0U4juty6Z4YqQgn/zQAAADz5VUPCRYdZleIzWpyNQAAAEBt/AYNAJqJNpFOtYl0akS3eN86t8fQ3tyS47pcdh92KddVoRU7D2vFzsO1jtMhLrxW4NKzemgxO7/UAAAAAeSbb4UhwQAAABCECFcAoBmzWS3qFB+hTvERGt33yNBiZZVubcsqrtXlsjmzSNlF5dqbW6K9uSVavDHLt73dZlHH1hHq2qaVuiREqGtCK3Vp413odAEAAI0hr8QbrsRGEK4AAAAg+PAbMQBogULtNvVrH61+7aNrrc91VRwJXDK9gcvWrCKVVLi1/VCxth8qljbUPlbb6FB1qQ5buh51G9/KwZwuAACgwXJdTGYPAACA4EW4AgDwiYtwaFiXeA3rcmRoMY/H0MHCMm0/VKwdh4q1Pdt7uyO7WDnFFTpQUKYDBWX6altOrWNFh9nVpU1ErcCla0IrtY8Nl81K6AIAAE6upnMlLoLJ7AEAABB8CFcAACdltVrULiZM7WLCdH73NrWeyy+p0I7sYl9Xy45sl7YfKta+vBIVlFZqzd58rdmbX2sfR4hVneMjvMOKJdR0u3gfh9ptAXxnAAAgmNXMucKwYAAAAAhGhCsAgAaLCXdocMc4De4YV2t9WaVbu3JcR4Uu3tudOS5VVHm0uXrIsaNZLFL72DBvl0vNEGMJ3vv8UgUAgJYnjwntAQAAEMQIVwAAfhdqt6lXcpR6JUfVWu/2GPopr1Tbs4u041B1+FIdvBSUVmpfbqn25ZZqyZbsWvvFRTjUtbrTpWaosc7xrZQQ5aTbBQCAZiqXCe0BAAAQxAhXAAABY7Na1KF1uDq0DteFPY+sNwxDh10Vtbpcth8q1s5sl37KL1Wuq0KrXLlatTv3uGNGhoaoTaRT8a2cahPpVJujbuMjHWrTKlTxkQ61jnDKEWIN4LsFAABngs4VAAAABDPCFQCA6SwWi+JbeQOSoZ1b13rOVV5V5xBjew6XqMLtUVFZlYrKqrQz23XK14kNt/tCGF8Yc9T9+FYOtYl0qnWEUzarpbHeLgAAOA10rgAAACCYEa4AAIJahDNEfdtFq2+76FrrDcNQYWmVsovLlF1UoezicuUUlde6zS4qV05xuXKKK+T2GMorqVReSaW2HSo+6WtaLFLrCEetbpj4o7pijg5jYsMdshLEAADgd3muSkne4UEBAACAYEO4AgBokiwWi6LD7YoOt6trwsm39XgM5ZdW+sKW7KLy2vePCmIOuypkGFJOcYVyiiu0ObPopMe2WS2Kb+U4viPmmECmTSunosJCZLEQxAAAcCrlVW4Vl1dJYlgwAAAABCfCFQBAs2e1WhQX4VBchEM9FHnSbavcHuWWVCjnmG6Yo8OYmtu8kkq5PYayCsuVVVh+yjocNqtv6LETD03mvY1w2AhiAAAtVn6Jt2vFZrUoMpTLVgAAAAQfvqUCAHCUEJtVCZGhSogMPeW2lW6PDhdX1NkFc2wwU1RWpQq3RwcKynSgoOyUxw6z2xQf6ThuKLJju2PaRDoVarf5460DABA0cqsns48NtzP8JgAAAIIS4QoAAA1kt1mVFB2qpOhTBzFllW7f/C/HDUtWc786kHFVuFVa6da+3FLtyy095bEjnSHHzAnjOK4bJjbcoaiwELVyhijEZvXH2wcAoNHk+cIVhgQDAABAcCJcAQAgAELtNrWPDVf72PBTbusqr6oOYo6EL9l1hTLF5aqo8qiovEpF5VXaleM6rVpaOUMUGRqiqFC7osK8t5GhIYoKsx+z7sh973Mhigy1yxFCOAMAaFy5JdXhCpPZAwAAIEgRrgAAEGQinCGKcIaoY+uIk25nGIaKyqu8gUsdc8N473tDmYLSSpVWuiVJxeVVKi6v0sHTGJ6sLqF263GBS839moDmSFhzVGhTfd8ZYmU+GQDASdV0rjCZPQAAAIIV4QoAAE2UxWKpDi3s6tKm1Sm3r3R7VFRWpcLSShWWVaqwtEqFZZUqOuq+97mqOtcVl1dJksoqPSqrLNehovIG1e2wWX0dMa1bOdQ6wqn4yJpbp+IjHIqPdKp19W2kM4QwBgBamFyXd0J7OlcAAAAQrAhXAABoIew2q+IiHIpr4C+q3B5DxWXewKWgtNIb1BwVvhQet84b0BSVV9+WVcpjSBVuj3KKK5RTXKGdpzGUmcNmVetWDsW3cta6bXP04+qAJi7cwZwyANAM5FUPCxYXYTe5EgAAAKBuhCsAAOC02KwWRYfbFR1uV0oD9vd4DLkqqnydMfkllTpcXKHDLu+wZjmuCuUUleuwq0I5xeU6XFyh4vIqVbg9OlhQdlrDmFksUkyYvVYQ410cal19/+hgJtzBVyEACEa5TGgPAACAIMdvFAAAQEBYrRZFhtoVGWqXFHZa+5RVun1BS81t9tGPXUfu57oq5DGkvJJK5ZVUatuhUx8/zG47MiRZdQgTG+FQK2eIIkO9Syun3fe4lTNErarXO0NsZ3ZCAAAndKRzhXAFAAAAwYlwBQAABK1Qu03tY8PVPjb8lNu6PYbySip8YYt3qdDh6vtH1ntvy6s8Kq10a19uqfbllta7NofNqlY1gUtN6FITwlSHMpFHPV+zPtJp9+3nDWmszCkDAMfwda4QrgAAACBIEa4AAIBmwWa1+IYB66HIk25rGIZcFW5f8JJzVGdMXkmFisuqVFzuXYpq7lcPZ+aqcEvyzh2T66rw/QKwoew2iy+caeW0K9J3/+hAJkThjhBFOG21bx0hCnfaFO6oeWxjzhkAzUJe9c/WOIYFAwAAQJAiXAEAAC2OxWLxdZR0bB1Rr33d1XPH1AQwRdWhS00Ac3QgU7P+6IDm6MeSVOk2fEOZSfXvoDmWI8SqiOqwJdxhU7gzxPe4JpQJd9i8607w3LFBTpjdRncNgIDKZVgwAAAABDnCFQAAgHqwWS2KCrUrKtR+Rsfx1IQ0NV0xNaFLWZWKyyuP6ZipkquiSiUVbrnKq1Ra6b2teVxS4VaVx5AkVVR5VFHlqQ5r/MNi8c5PU7trxqYwh00Om1UhNovsNmv1YlGIzSq71bsuxGaVo2Zd9fP2mn2sVtlDLAqx1vFc9fYhVoscId7b416jZnurhfAHaEZKK9wqq/RIYlgwAAAABC/CFQAAABNYrRZFhtoVGWqXos/sWIZhqMLtUWmFW64Kt0rKq2rfVtQOYlwVVSopd6uk+rm6tq157D2+qrd1K6fYD2++EdhtNSGNRY6QmqHSbAq1H7kf5ghRuN0bCtV+PqT6+aO2tR9ZF+awKdzOkGtAoNR0rThs3k48AAAAIBgRrgAAADRxFotFzhCbnCE2xYT777gej6GyKrdc5UeFLhVVtR5Xuj2qdBuqdHtU5TZU6fGosspQlcejipp1tbbxqNJjqLLKoypPzXPe56vcHlVU31Z5DFVUeVTlObJvzWvUdOkczbuNW6WVklTlv5NwFIfN6gtgwhy26m6eI6HN0QFNmCPkqOe9t3HhDg3rGt8otQHNSZ5vMns7XWkAAAAIWoQrAAAAqJPVaqnu6giR5DS7HB/DMLxhTHWQU+k5ErxUuD0qr/SotNKt0uowqLTS7eu8KT3qcWnFUesrq3zraj9fpZosp8LtUUWpRwWlDRtyrVN8hL743QX+OxFoNmbMmKFnn31WmZmZGjBggP7+979ryJAhJ9w+Pz9fDz30kN59913l5uaqY8eOevHFF3XppZc2+JjBJLcmXGEyewAAAAQxwhUAAAA0KRaLRY4QixyySo38u1fDMFRe5R1yraSyOpyp8Hg7dyqPBDSlvs4et8oqjw9tSircSo4Obdxi0STNnz9fU6ZM0cyZM5WWlqYXX3xRo0aN0pYtW5SQkHDc9hUVFbr44ouVkJCgt99+W+3atdOePXsUExPT4GMGm1C7TUM7x6ljXITZpQAAAAAnZDEM4/hxFZqxwsJCRUdHq6CgQFFRUWaXAwAAADQ6vgMHr7S0NJ1zzjl66aWXJEkej0cpKSm699579eCDDx63/cyZM/Xss89q8+bNstvtfjlmXfjMAAAAoCVpyPdfZuUEAAAAABNUVFRo9erVGjlypG+d1WrVyJEjtWLFijr3+eCDD5Senq7JkycrMTFRffv21ZNPPim3293gY0pSeXm5CgsLay0AAAAAToxwBQAAAABMkJOTI7fbrcTExFrrExMTlZmZWec+O3fu1Ntvvy23262FCxfq4Ycf1vPPP68nnniiwceUpOnTpys6Otq3pKSknOG7AwAAAJq3oAhXZsyYodTUVIWGhiotLU2rVq066fYLFixQz549FRoaqn79+mnhwoUBqhQAAAAAzOPxeJSQkKBXXnlFgwcP1rhx4/TQQw9p5syZZ3TcqVOnqqCgwLfs27fPTxUDAAAAzZPp4UrNZIvTpk3TmjVrNGDAAI0aNUqHDh2qc/uvv/5aN9xwgyZOnKjvv/9eY8eO1dixY7V+/foAVw4AAAAADRcfHy+bzaasrKxa67OyspSUlFTnPsnJyerevbtsNptvXa9evZSZmamKiooGHVOSnE6noqKiai0AAAAATsz0cOWFF17QHXfcoQkTJqh3796aOXOmwsPDNWfOnDq3/+tf/6rRo0fr97//vXr16qXHH39cgwYN8k3WCAAAAABNgcPh0ODBg5WRkeFb5/F4lJGRofT09Dr3GT58uLZv3y6Px+Nbt3XrViUnJ8vhcDTomAAAAADqz9RwpSGTLa5YsaLW9pI0atSoE27PxIwAAAAAgtWUKVM0a9YszZ07V5s2bdKkSZPkcrk0YcIESdL48eM1depU3/aTJk1Sbm6u7rvvPm3dulUfffSRnnzySU2ePPm0jwkAAADgzIWY+eInm2xx8+bNde6TmZlZr8kZp0+frscee8w/BQMAAACAH40bN07Z2dl65JFHlJmZqYEDB2rRokW+a569e/fKaj3yN3EpKSn65JNP9Jvf/Eb9+/dXu3btdN999+mBBx447WMCAAAAOHOmhiuBMHXqVE2ZMsX3uLCwUCkpKSZWBAAAAABH3HPPPbrnnnvqfG7JkiXHrUtPT9fKlSsbfEwAAAAAZ87UcKUhky0mJSXVa3un0ymn0+mfggEAAAAAAAAAQItn6pwrDZlsMT09vdb2krR48WImZwQAAAAAAAAAAAFh+rBgU6ZM0S233KKzzz5bQ4YM0YsvvnjcBI7t2rXT9OnTJUn33Xefzj//fD3//PO67LLLNG/ePH333Xd65ZVXzHwbAAAAAAAAAACghTA9XKnvBI7Dhg3Tf/7zH/3xj3/UH/7wB3Xr1k3vv/+++vbta9ZbAAAAAAAAAAAALYjFMAzD7CICqbCwUNHR0SooKFBUVJTZ5QAAAACNju/AqC8+MwAAAGhJGvL919Q5VwAAAAAAAAAAAJoawhUAAAAAAAAAAIB6IFwBAAAAAAAAAACoB8IVAAAAAAAAAACAeiBcAQAAAAAAAAAAqAfCFQAAAAAAAAAAgHogXAEAAAAAAAAAAKgHwhUAAAAAAAAAAIB6IFwBAAAAAAAAAACoB8IVAAAAAAAAAACAeiBcAQAAAAAAAAAAqAfCFQAAAAAAAAAAgHoIMbuAQDMMQ5JUWFhociUAAABAYNR89635LgycCtdNAAAAaEkacs3U4sKVoqIiSVJKSorJlQAAAACBVVRUpOjoaLPLQBPAdRMAAABaovpcM1mMFvbnax6PRwcOHFBkZKQsFkvAX7+wsFApKSnat2+foqKiAv76LRXn3Tyce3Nw3s3BeTcH590cnHfzNOTcG4ahoqIitW3bVlYrIwPj1Lhuapk47+bgvJuD824ezr05OO/m4LybI1DXTC2uc8Vqtap9+/Zml6GoqCj+hzIB5908nHtzcN7NwXk3B+fdHJx389T33NOxgvrguqll47ybg/NuDs67eTj35uC8m4Pzbo7Gvmbiz9YAAAAAAAAAAADqgXAFAAAAAAAAAACgHghXAszpdGratGlyOp1ml9KicN7Nw7k3B+fdHJx3c3DezcF5Nw/nHi0Bn3NzcN7NwXk3B+fdPJx7c3DezcF5N0egznuLm9AeAAAAAAAAAADgTNC5AgAAAAAAAAAAUA+EKwAAAAAAAAAAAPVAuAIAAAAAAAAAAFAPhCsAAAAAAAAAAAD1QLjSCGbMmKHU1FSFhoYqLS1Nq1atOun2CxYsUM+ePRUaGqp+/fpp4cKFAaq0+Zg+fbrOOeccRUZGKiEhQWPHjtWWLVtOus9rr70mi8VSawkNDQ1Qxc3Do48+etw57Nmz50n34fN+5lJTU4877xaLRZMnT65zez7rDfPll1/q8ssvV9u2bWWxWPT+++/Xet4wDD3yyCNKTk5WWFiYRo4cqW3btp3yuPX9N6KlOdl5r6ys1AMPPKB+/fopIiJCbdu21fjx43XgwIGTHrMhP6taolN95m+99dbjzuPo0aNPeVw+8yd3qvNe1897i8WiZ5999oTH5DOPpoLrpsDimskcXDOZh+umwOC6yRxcN5mDayZzBPM1E+GKn82fP19TpkzRtGnTtGbNGg0YMECjRo3SoUOH6tz+66+/1g033KCJEyfq+++/19ixYzV27FitX78+wJU3bUuXLtXkyZO1cuVKLV68WJWVlbrkkkvkcrlOul9UVJQOHjzoW/bs2ROgipuPPn361DqHy5YtO+G2fN7949tvv611zhcvXixJuvbaa0+4D5/1+nO5XBowYIBmzJhR5/PPPPOM/va3v2nmzJn65ptvFBERoVGjRqmsrOyEx6zvvxEt0cnOe0lJidasWaOHH35Ya9as0bvvvqstW7boiiuuOOVx6/OzqqU61WdekkaPHl3rPL755psnPSaf+VM71Xk/+nwfPHhQc+bMkcVi0dVXX33S4/KZR7DjuinwuGYyD9dM5uC6KTC4bjIH103m4JrJHEF9zWTAr4YMGWJMnjzZ99jtdhtt27Y1pk+fXuf21113nXHZZZfVWpeWlmbcddddjVpnc3fo0CFDkrF06dITbvPqq68a0dHRgSuqGZo2bZoxYMCA096ez3vjuO+++4wuXboYHo+nzuf5rJ85ScZ7773ne+zxeIykpCTj2Wef9a3Lz883nE6n8eabb57wOPX9N6KlO/a812XVqlWGJGPPnj0n3Ka+P6tQ97m/5ZZbjCuvvLJex+EzXz+n85m/8sorjQsvvPCk2/CZR1PAdZP5uGYKDK6ZggfXTY2P6yZzcN1kDq6ZzBFs10x0rvhRRUWFVq9erZEjR/rWWa1WjRw5UitWrKhznxUrVtTaXpJGjRp1wu1xegoKCiRJcXFxJ92uuLhYHTt2VEpKiq688kpt2LAhEOU1K9u2bVPbtm3VuXNn3XTTTdq7d+8Jt+Xz7n8VFRV6/fXXddttt8lisZxwOz7r/rVr1y5lZmbW+jxHR0crLS3thJ/nhvwbgVMrKCiQxWJRTEzMSberz88qnNiSJUuUkJCgHj16aNKkSTp8+PAJt+Uz739ZWVn66KOPNHHixFNuy2cewYzrpuDANVPgcM1kPq6bzMF1U/DguilwuGYyV6CvmQhX/CgnJ0dut1uJiYm11icmJiozM7POfTIzM+u1PU7N4/Ho/vvv1/Dhw9W3b98TbtejRw/NmTNH//3vf/X666/L4/Fo2LBh2r9/fwCrbdrS0tL02muvadGiRXr55Ze1a9cunXvuuSoqKqpzez7v/vf+++8rPz9ft9566wm34bPufzWf2fp8nhvybwROrqysTA888IBuuOEGRUVFnXC7+v6sQt1Gjx6tf//738rIyNDTTz+tpUuXasyYMXK73XVuz2fe/+bOnavIyEhdddVVJ92OzzyCHddN5uOaKXC4ZgoOXDeZg+um4MB1U+BwzWS+QF8zhZxJsUAwmjx5stavX3/KcfLS09OVnp7uezxs2DD16tVL//znP/X44483dpnNwpgxY3z3+/fvr7S0NHXs2FFvvfXWaSXEOHOzZ8/WmDFj1LZt2xNuw2cdzVFlZaWuu+46GYahl19++aTb8rPKP66//nrf/X79+ql///7q0qWLlixZoosuusjEylqOOXPm6Kabbjrl5Lp85gGcCtdMgcPP5ODAdRNaKq6bAotrJvMF+pqJzhU/io+Pl81mU1ZWVq31WVlZSkpKqnOfpKSkem2Pk7vnnnv04Ycf6osvvlD79u3rta/dbtdZZ52l7du3N1J1zV9MTIy6d+9+wnPI592/9uzZo88++0y33357vfbjs37maj6z9fk8N+TfCNSt5gJhz549Wrx48Un/+qoup/pZhdPTuXNnxcfHn/A88pn3r6+++kpbtmyp9898ic88gg/XTebimslcXDMFHtdN5uG6yVxcN5mPa6bAMuOaiXDFjxwOhwYPHqyMjAzfOo/Ho4yMjFp//XC09PT0WttL0uLFi0+4PepmGIbuuecevffee/r888/VqVOneh/D7XZr3bp1Sk5OboQKW4bi4mLt2LHjhOeQz7t/vfrqq0pISNBll11Wr/34rJ+5Tp06KSkpqdbnubCwUN98880JP88N+TcCx6u5QNi2bZs+++wztW7dut7HONXPKpye/fv36/Dhwyc8j3zm/Wv27NkaPHiwBgwYUO99+cwj2HDdZA6umYID10yBx3WTebhuMg/XTcGBa6bAMuWa6TQnvsdpmjdvnuF0Oo3XXnvN2Lhxo3HnnXcaMTExRmZmpmEYhnHzzTcbDz74oG/75cuXGyEhIcZzzz1nbNq0yZg2bZpht9uNdevWmfUWmqRJkyYZ0dHRxpIlS4yDBw/6lpKSEt82x577xx57zPjkk0+MHTt2GKtXrzauv/56IzQ01NiwYYMZb6FJ+u1vf2ssWbLE2LVrl7F8+XJj5MiRRnx8vHHo0CHDMPi8Nya322106NDBeOCBB457js+6fxQVFRnff/+98f333xuSjBdeeMH4/vvvjT179hiGYRhPPfWUERMTY/z3v/81fvzxR+PKK680OnXqZJSWlvqOceGFFxp///vffY9P9W8ETn7eKyoqjCuuuMJo3769sXbt2lo/78vLy33HOPa8n+pnFbxOdu6LioqM3/3ud8aKFSuMXbt2GZ999pkxaNAgo1u3bkZZWZnvGHzm6+9UP2sMwzAKCgqM8PBw4+WXX67zGHzm0RRx3RR4XDOZg2smc3Hd1Pi4bjIH103m4JrJHMF8zUS40gj+/ve/Gx06dDAcDocxZMgQY+XKlb7nzj//fOOWW26ptf1bb71ldO/e3XA4HEafPn2Mjz76KMAVN32S6lxeffVV3zbHnvv777/f998pMTHRuPTSS401a9YEvvgmbNy4cUZycrLhcDiMdu3aGePGjTO2b9/ue57Pe+P55JNPDEnGli1bjnuOz7p/fPHFF3X+XKk5tx6Px3j44YeNxMREw+l0GhdddNFx/z06duxoTJs2rda6k/0bgZOf9127dp3w5/0XX3zhO8ax5/1UP6vgdbJzX1JSYlxyySVGmzZtDLvdbnTs2NG44447jvvCz2e+/k71s8YwDOOf//ynERYWZuTn59d5DD7zaKq4bgosrpnMwTWTubhuanxcN5mD6yZzcM1kjmC+ZrIYhmHUr9cFAAAAAAAAAACg5WLOFQAAAAAAAAAAgHogXAEAAAAAAAAAAKgHwhUAAAAAAAAAAIB6IFwBAAAAAAAAAACoB8IVAAAAAAAAAACAeiBcAQAAAAAAAAAAqAfCFQAAAAAAAAAAgHogXAEAAAAAAAAAAKgHwhUAQNCzWCx6//33zS4DAAAAAIIS10wAEHiEKwCAk7r11ltlsViOW0aPHm12aQAAAABgOq6ZAKBlCjG7AABA8Bs9erReffXVWuucTqdJ1QAAAABAcOGaCQBaHjpXAACn5HQ6lZSUVGuJjY2V5G0/f/nllzVmzBiFhYWpc+fOevvtt2vtv27dOl144YUKCwtT69atdeedd6q4uLjWNnPmzFGfPn3kdDqVnJyse+65p9bzOTk5+sUvfqHw8HB169ZNH3zwQeO+aQAAAAA4TVwzAUDLQ7gCADhjDz/8sK6++mr98MMPuummm3T99ddr06ZNkiSXy6VRo0YpNjZW3377rRYsWKDPPvus1oXAyy+/rMmTJ+vOO+/UunXr9MEHH6hr1661XuOxxx7Tddddpx9//FGXXnqpbrrpJuXm5gb0fQIAAABAQ3DNBADNj8UwDMPsIgAAwevWW2/V66+/rtDQ0Frr//CHP+gPf/iDLBaLfvWrX+nll1/2PTd06FANGjRI//jHPzRr1iw98MAD2rdvnyIiIiRJCxcu1OWXX64DBw4oMTFR7dq104QJE/TEE0/UWYPFYtEf//hHPf7445K8Fx+tWrXSxx9/zDjGAAAAAEzFNRMAtEzMuQIAOKWf/exntS4EJCkuLs53Pz09vdZz6enpWrt2rSRp06ZNGjBggO8iQZKGDx8uj8ejLVu2yGKx6MCBA7roootOWkP//v199yMiIhQVFaVDhw419C0BAAAAgN9wzQQALQ/hCgDglCIiIo5rOfeXsLCw09rObrfXemyxWOTxeBqjJAAAAACoF66ZAKDlYc4VAMAZW7ly5XGPe/XqJUnq1auXfvjhB7lcLt/zy5cvl9VqVY8ePRQZGanU1FRlZGQEtGYAAAAACBSumQCg+aFzBQBwSuXl5crMzKy1LiQkRPHx8ZKkBQsW6Oyzz9aIESP0xhtvaNWqVZo9e7Yk6aabbtK0adN0yy236NFHH1V2drbuvfde3XzzzUpMTJQkPfroo/rVr36lhIQEjRkzRkVFRVq+fLnuvffewL5RAAAAAGgArpkAoOUhXAEAnNKiRYuUnJxca12PHj20efNmSdJjjz2mefPm6e6771ZycrLefPNN9e7dW5IUHh6uTz75RPfdd5/OOecchYeH6+qrr9YLL7zgO9Ytt9yisrIy/eUvf9Hvfvc7xcfH65prrgncGwQAAACAM8A1EwC0PBbDMAyziwAANF0Wi0Xvvfeexo4da3YpAAAAABB0uGYCgOaJOVcAAAAAAAAAAADqgXAFAAAAAAAAAACgHhgWDAAAAAAAAAAAoB7oXAEAAAAAAAAAAKgHwhUAAAAAAAAAAIB6IFwBAAAAAAAAAACoB8IVAAAAAAAAAACAeiBcAQAAAAAAAAAAqAfCFQAAAAAAAAAAgHogXAEAAAAAAAAAAKgHwhUAAAAAAAAAAIB6+P/IM9XO6eQFDAAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<Figure size 2000x800 with 2 Axes>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "def plot_history(history):\n",
+        "  \"\"\"\n",
+        "    Plotting training and validation learning curves.\n",
+        "\n",
+        "    Args:\n",
+        "      history: model history with all the metric measures\n",
+        "  \"\"\"\n",
+        "  fig, (ax1, ax2) = plt.subplots(1,2)\n",
+        "  fig.set_size_inches(20, 8)\n",
+        "\n",
+        "  # Plot loss\n",
+        "  ax1.set_title('Loss')\n",
+        "  ax1.plot(history.history['loss'], label = 'train')\n",
+        "  ax1.plot(history.history['val_loss'], label = 'test')\n",
+        "  ax1.set_ylabel('Loss')\n",
+        "\n",
+        "  ax1.set_xlabel('Epoch')\n",
+        "  ax1.legend(['Train', 'Validation'])\n",
+        "\n",
+        "  # Plot accuracy\n",
+        "  ax2.set_title('Accuracy')\n",
+        "  ax2.plot(history.history['accuracy'],  label = 'train')\n",
+        "  ax2.plot(history.history['val_accuracy'], label = 'test')\n",
+        "  ax2.set_ylabel('Accuracy')\n",
+        "  ax2.set_xlabel('Epoch')\n",
+        "  ax2.legend(['Train', 'Validation'])\n",
+        "\n",
+        "  plt.show()\n",
+        "\n",
+        "plot_history(history)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kOgva0pbP4FS"
+      },
+      "source": [
+        "Another way to view model performance, beyond just measuring loss and accuracy is to use a confusion matrix. The confusion matrix allows you to assess the performance of the classification model beyond accuracy. You can see what misclassified points get classified as. In order to build the confusion matrix for this multi-class classification problem, get the actual values in the test set and the predicted values.\n",
+        "\n",
+        "Start by generating the predicted class for each example in the validation set using `Model.predict()`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "PRUx5ao9QRcO",
+        "outputId": "593b37b0-ba4a-4919-c55f-82e863bd1b89"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "4/4 [==============================] - 0s 2ms/step\n"
+          ]
+        }
+      ],
+      "source": [
+        "y_hat = classifier.predict(x=x_val)\n",
+        "y_hat = np.argmax(y_hat, axis=1)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "CVidbr0OT5tL",
+        "outputId": "a275d2c0-d4de-4882-da37-10df4036df4a"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'sci.crypt': 0, 'sci.electronics': 1, 'sci.med': 2, 'sci.space': 3}"
+            ]
+          },
+          "execution_count": 24,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "labels_dict = dict(zip(df_test['Class Name'], df_test['Encoded Label']))\n",
+        "labels_dict"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3ae76701e178",
+        "outputId": "efd24b1f-a98c-48a5-92b6-31e6c4f50fba"
+      },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAksAAAIbCAYAAAD7M9r1AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAB3DklEQVR4nO3deVhU1f8H8PeAMIDsm4Aii7ihiGumuIZBmJaolXwtcc8S9z1TwT3L3cLcl7IsNTMzFXHfMFNRU0kQd1QQ2WWd8/uDH1Mji+BcGBjer+e5j86Ze8/9zOXOzGfOOfdcmRBCgIiIiIiKpKPpAIiIiIgqMyZLRERERCVgskRERERUAiZLRERERCVgskRERERUAiZLRERERCVgskRERERUAiZLRERERCVgskRERERUAiZLVGXcvHkTPj4+MDMzg0wmw+7duyWt//bt25DJZNi0aZOk9WoDZ2dnDBw4ULL6Hj9+jL59+8LKygoymQzLli2TrG4idWzatAkymQy3b9/WdChUiTBZojKJiYnBxx9/DFdXVxgYGMDU1BReXl5Yvnw5nj9/Xq77DgwMxJUrVzBv3jxs3boVrVu3Ltf9aaNr164hODhY418E48aNw4EDBzBt2jRs3boVb731lkbjofK1b98+BAcHl+s+MjIyEBwcjKNHj5brfkqybdu2SpP4V4bjoVUEUSnt3btXGBoaCnNzczF69GixZs0asWrVKtGvXz+hp6cnhg0bVm77zsjIEADE9OnTy20fCoVCPH/+XOTm5pbbPjTt559/FgDEkSNHyrRdZmamyM7OliyOWrVqif79+0tWH1VuI0eOFOX9dRMfHy8AiFmzZqlVz8aNGwUAERsbW+Zt3377beHk5KTW/qUi1fGgfDU0mahR1REbG4t+/frByckJhw8fhr29vfK5kSNHIjo6Gr///nu57T8+Ph4AYG5uXm77kMlkMDAwKLf6qxohBDIzM2FoaAi5XC5p3U+ePJH0b5mZmQl9fX3o6FTvxvL09HTUrFlT02EQaR9NZ2tUNYwYMUIAEKdOnSrV+jk5OWL27NnC1dVV6OvrCycnJzFt2jSRmZmpsp6Tk5N4++23xYkTJ0SbNm2EXC4XLi4uYvPmzcp1Zs2aJQCoLAW/3gIDA4v8JVewzX8dPHhQeHl5CTMzM1GzZk3RoEEDMW3aNOXzsbGxAoDYuHGjynbh4eGiQ4cOwsjISJiZmYl33nlHXLt2rcj93bx5UwQGBgozMzNhamoqBg4cKNLT0196vDp37iyaNGkiIiMjRadOnYShoaGoV6+e+Pnnn4UQQhw9elS89tprwsDAQDRo0ECEhYWpbH/79m3xySefiAYNGggDAwNhaWkp+vbtq/LruOAX84tLQStTwd9i//79olWrVkIul4ulS5cqnwsMDBRC5LfAdenSRVhbW4vHjx8r68/KyhJNmzYVrq6uIi0trcjXWVwMBWJiYkTfvn2FhYWFMDQ0FG3bthV79+5VqePIkSMCgPjhhx/E9OnThYODg5DJZOLZs2dF7rPg7/rll1+Kb7/9VnlOtm7dWpw7d67Q+tevXxd9+vQRFhYWQi6Xi1atWolff/1V+fyzZ8+Ejo6OWL58ubIsPj5eyGQyYWlpKRQKhbJ8xIgRolatWsrH//zzj+jdu7eoVauWkMvlonbt2uKDDz4QSUlJynUyMjLEqFGjhJWVlTA2NhY9e/YU9+/fL9RKUHDO/f333yIgIECYm5uL5s2bCyFK//57sc4C//17C/Hv3+3YsWNi+PDhwtLSUpiYmIiPPvpIJCYmFnncCwQGBpb4N8/LyxNLly4V7u7uQi6XC1tbWzF8+PBC9f7555/Cx8dHWFlZCQMDA+Hs7CwGDRokhPj3b/zi8rJWlatXr4quXbsKAwMDUbt2bTFnzhyxfv36Qi1Lu3fvFt27dxf29vZCX19fuLq6itmzZ6u0Qnfu3LnYz6msrCwxY8YM0bJlS2FqaiqMjIxEhw4dxOHDhwvF9MMPP4iWLVsKY2NjYWJiIpo2bSqWLVumss6zZ8/EmDFjRJ06dYS+vr6oV6+eWLhwocjLy1PreFDx2LJEpfLbb7/B1dUV7du3L9X6Q4cOxebNm9G3b19MmDABERERWLBgAa5fv45ffvlFZd3o6Gj07dsXQ4YMQWBgIDZs2ICBAweiVatWaNKkCXr37g1zc3OMGzcOAQEB6N69O4yNjcsU/99//40ePXqgWbNmmD17NuRyOaKjo3Hq1KkStzt06BD8/Pzg6uqK4OBgPH/+HCtXroSXlxcuXLgAZ2dnlfXff/99uLi4YMGCBbhw4QLWrVsHW1tbfPHFFy+N8dmzZ+jRowf69euH9957D6GhoejXrx++//57jB07FiNGjMD//vc/fPnll+jbty/u3bsHExMTAMCff/6J06dPo1+/fqhTpw5u376N0NBQdOnSBdeuXYORkRE6deqE0aNHY8WKFfjss8/QuHFjAFD+CwBRUVEICAjAxx9/jGHDhqFhw4aF4pTJZNiwYQOaNWuGESNGYNeuXQCAWbNm4e+//8bRo0eLbd3o1KkTtm7dio8++ghvvvkmBgwYoHzu8ePHaN++PTIyMjB69GhYWVlh8+bNeOedd7Bjxw74+/ur1DVnzhzo6+tj4sSJyMrKgr6+fonHd9u2bUhNTcXHH38MmUyGRYsWoXfv3rh16xb09PQA5J8nXl5eqF27NqZOnYqaNWvip59+Qq9evbBz5074+/vD3NwcTZs2xfHjxzF69GgAwMmTJyGTyZCYmIhr166hSZMmAIATJ06gY8eOAIDs7Gz4+voiKysLo0aNgp2dHR48eIC9e/ciKSkJZmZmAICBAwfip59+wkcffYTXX38dx44dw9tvv13s63rvvfdQv359zJ8/H0IIAGV7/5VFUFAQzM3NERwcjKioKISGhuLOnTs4evQoZDJZkdt8/PHHePjwIcLCwrB169Yin9+0aRMGDRqE0aNHIzY2FqtWrcLFixdx6tQp6Onp4cmTJ/Dx8YGNjQ2mTp0Kc3Nz3L59W3nu2djYIDQ0FJ988gn8/f3Ru3dvAECzZs2KfS2PHj1C165dkZubq/xbr1mzBoaGhoXW3bRpE4yNjTF+/HgYGxvj8OHDmDlzJlJSUvDll18CAKZPn47k5GTcv38fS5cuBQDl51RKSgrWrVuHgIAADBs2DKmpqVi/fj18fX1x7tw5NG/eHAAQFhaGgIAAeHt7Kz8zrl+/jlOnTmHMmDEA8scide7cGQ8ePMDHH3+MunXr4vTp05g2bRri4uKwbNmyVzoe9BKaztao8ktOThYAxLvvvluq9S9duiQAiKFDh6qUT5w4UQBQ+TXl5OQkAIjjx48ry548eSLkcrmYMGGCsuy/rQP/VdqWpaVLlwoAIj4+vti4i2pZat68ubC1tRVPnz5VlkVGRgodHR0xYMCAQvsbPHiwSp3+/v7Cysqq2H0WKPhVum3bNmXZjRs3BACho6Mjzp49qyw/cOBAoTgzMjIK1XnmzBkBQGzZskVZVtKYpYK/xf79+4t87r8tDUII8e233woA4rvvvhNnz54Vurq6YuzYsS99rULkt2iMHDlSpWzs2LECgDhx4oSyLDU1Vbi4uAhnZ2flr+aCliVXV9ciX/eLCv6uVlZWKq0Vv/76qwAgfvvtN2WZt7e38PDwUGmBUSgUon379qJ+/frKspEjR6q0GI0fP1506tRJ2NraitDQUCGEEE+fPhUymUzZAnXx4kUBQNlaWJS//vpLACh0HAcOHFhsy1JAQIDKumV5/71YZ4HiWpZatWqlMnZt0aJFAoBKy1tRihuzdOLECQFAfP/99yrl+/fvVyn/5ZdfBADx559/FruPso7RKTjfIiIilGVPnjwRZmZmhVqWijrPPv74Y2FkZKRyrhQ3Zik3N1dkZWWplD179kzUqlVL5TNjzJgxwtTUtMRxk3PmzBE1a9YU//zzj0r51KlTha6urrh7964QgmOWpFa9O/ipVFJSUgBA2YrxMvv27QMAjB8/XqV8woQJAFBobJO7u7vy1zeQ/yuxYcOGuHXr1ivH/KKC8TG//vorFApFqbaJi4vDpUuXMHDgQFhaWirLmzVrhjfffFP5Ov9rxIgRKo87duyIp0+fKo9hSYyNjdGvXz/l44YNG8Lc3ByNGzdG27ZtleUF///v8fnvr+GcnBw8ffoUbm5uMDc3x4ULF0rxavO5uLjA19e3VOsOHz4cvr6+GDVqFD766CPUq1cP8+fPL/W+XrRv3z689tpr6NChg7LM2NgYw4cPx+3bt3Ht2jWV9QMDA4tsBSjOBx98AAsLC+XjgnOu4DgmJibi8OHDeP/995GamoqEhAQkJCTg6dOn8PX1xc2bN/HgwQPlto8fP0ZUVBSA/BakTp06oWPHjjhx4gSA/NYmIYRyPwUtRwcOHEBGRkaRMe7fvx8A8Omnn6qUjxo1qtjX9eI5V9b3X1kMHz5c2QoHAJ988glq1KhR5HuhNH7++WeYmZnhzTffVB7vhIQEtGrVCsbGxjhy5AiAf9+/e/fuRU5OzivH/1/79u3D66+/jtdee01ZZmNjg/79+xda97/nWcG50bFjR2RkZODGjRsv3Zeurq6y5VOhUCAxMRG5ublo3bq1yvvT3Nwc6enpCAsLK7aun3/+GR07doSFhYXKMevWrRvy8vJw/PjxUr1+KhsmS/RSpqamAPI/JErjzp070NHRgZubm0q5nZ0dzM3NcefOHZXyunXrFqrDwsICz549e8WIC/vggw/g5eWFoUOHolatWujXrx9++umnEhOngjiL6opq3LgxEhISkJ6erlL+4msp+HIuzWupU6dOoa4MMzMzODo6Fip7sc7nz59j5syZcHR0hFwuh7W1NWxsbJCUlITk5OSX7ruAi4tLqdcFgPXr1yMjIwM3b97Epk2bypS8vOjOnTvFHuuC59WJ9WV/m+joaAghMGPGDNjY2Kgss2bNApA/MB34N9E6ceIE0tPTcfHiRXTs2BGdOnVSJksnTpyAqakpPD09lfGOHz8e69atg7W1NXx9ffH111+r/H0K3jsvvrYX30slHYeyvv/Kon79+iqPjY2NYW9v/8pTUdy8eRPJycmwtbUtdMzT0tKUx7tz587o06cPQkJCYG1tjXfffRcbN25EVlbWK7+WO3fuFHo9QNHv97///hv+/v4wMzODqakpbGxs8OGHHwJAqd9fmzdvRrNmzWBgYAArKyvY2Njg999/V9n+008/RYMGDeDn54c6depg8ODBygS6wM2bN7F///5Cx6tbt24A/j1HSVocs0QvZWpqCgcHB1y9erVM2xU3huFFurq6RZaL/x9/8Sr7yMvLU3lsaGiI48eP48iRI/j999+xf/9+bN++HW+88QYOHjxYbAxlpc5rKW7b0tQ5atQobNy4EWPHjkW7du2UE3f269ev1C1pAMqc7Bw9elT5hXXlyhW0a9euTNuro6yxvuw4FhyniRMnFtu6VpCAODg4wMXFBcePH4ezszOEEGjXrh1sbGwwZswY3LlzBydOnED79u1VrtBbvHgxBg4ciF9//RUHDx7E6NGjsWDBApw9exZ16tQp0+spUNxxKO37rygvvn/Ki0KhgK2tLb7//vsin7exsQGQ/1p27NiBs2fP4rfffsOBAwcwePBgLF68GGfPni3zGMaySEpKQufOnWFqaorZs2ejXr16MDAwwIULFzBlypRSvb++++47DBw4EL169cKkSZNga2sLXV1dLFiwADExMcr1bG1tcenSJRw4cAB//PEH/vjjD2zcuBEDBgzA5s2bAeQfszfffBOTJ08ucl8NGjSQ5oWTCiZLVCo9evTAmjVrcObMmZd+ITo5OUGhUODmzZsqg4cfP36MpKQkODk5SRaXhYUFkpKSCpUX9etZR0cH3t7e8Pb2xpIlSzB//nxMnz4dR44cUf4qe/F1AFB2tfzXjRs3YG1tXWku096xYwcCAwOxePFiZVlmZmahY6POF+iL4uLiMGrUKPj4+CgHWvv6+r7y39fJyanYY13wfHlydXUFAOjp6RV5PryoY8eOOH78OFxcXNC8eXOYmJjA09MTZmZm2L9/Py5cuICQkJBC23l4eMDDwwOff/45Tp8+DS8vL6xevRpz585VvndiY2NVWj2io6NL/TrK8v4r6v2TnZ2NuLi4Iuu+efMmunbtqnyclpaGuLg4dO/evcSYijvv6tWrh0OHDsHLy6tUye/rr7+O119/HfPmzcO2bdvQv39//Pjjjxg6dGiZz20nJyfcvHmzUPmL5+DRo0fx9OlT7Nq1C506dVKWx8bGFtq2uBh27NgBV1dX7Nq1S2WdghbL/9LX10fPnj3Rs2dPKBQKfPrpp/j2228xY8YMuLm5oV69ekhLS3vpOSrle53YDUelNHnyZNSsWRNDhw7F48ePCz0fExOD5cuXA4Dyg/PFmWyXLFkCACVe2VNW9erVQ3JyMi5fvqwsi4uLK3TFT2JiYqFtC65AKa4p397eHs2bN8fmzZtVvlCuXr2KgwcPvvQLoiLp6uoWar1auXJloRaCguSuqASzrIYNGwaFQoH169djzZo1qFGjBoYMGVKqVrSidO/eHefOncOZM2eUZenp6VizZg2cnZ3h7u6udswlsbW1RZcuXfDtt98WmSwUzPVVoGPHjrh9+za2b9+u7JbT0dFB+/btsWTJEuTk5KiMxUtJSUFubq5KHR4eHtDR0VGegwUtWt98843KeitXriz16yjL+69evXqFxrisWbOm2JalNWvWqIwZCg0NRW5uLvz8/EqMqbjz7v3330deXh7mzJlTaJvc3Fzl+s+ePSt0Xr34/jUyMipyH8Xp3r07zp49i3PnzinL4uPjC7VyFbRI/nf/2dnZhf5GQP7rLKpbrqg6IiIiVM51AHj69KnKYx0dHeUVbAWv8/3338eZM2dw4MCBQvtJSkpSnmNlPR5UMrYsUanUq1cP27ZtwwcffIDGjRtjwIABaNq0KbKzs3H69Gn8/PPPynuHeXp6IjAwEGvWrFE2YZ87dw6bN29Gr169VH6Zqqtfv36YMmUK/P39MXr0aGRkZCA0NBQNGjRQGTg5e/ZsHD9+HG+//TacnJzw5MkTfPPNN6hTp47KgOIXffnll/Dz80O7du0wZMgQ5dQBZmZm5X77hrLo0aMHtm7dCjMzM7i7u+PMmTM4dOgQrKysVNZr3rw5dHV18cUXXyA5ORlyuRxvvPEGbG1ty7S/jRs34vfff8emTZuU3UcrV67Ehx9+iNDQ0EIDlEtj6tSp+OGHH+Dn54fRo0fD0tISmzdvRmxsLHbu3FkhE05+/fXX6NChAzw8PDBs2DC4urri8ePHOHPmDO7fv4/IyEjlugWJUFRUlMrA9k6dOuGPP/6AXC5HmzZtlOWHDx9GUFAQ3nvvPTRo0AC5ubnYunUrdHV10adPHwBAq1at0KdPHyxbtgxPnz5VTh3wzz//AChda0FZ3n9Dhw7FiBEj0KdPH7z55puIjIzEgQMHYG1tXWTd2dnZ8Pb2xvvvv4+oqCh888036NChA955550SY2rVqhUAYPTo0fD19YWuri769euHzp074+OPP8aCBQtw6dIl+Pj4QE9PDzdv3sTPP/+M5cuXo2/fvti8eTO++eYb+Pv7o169ekhNTcXatWthamqqTA4NDQ3h7u6O7du3o0GDBrC0tETTpk3RtGnTImOaPHmy8lY7Y8aMUU4d4OTkpPLjq3379rCwsEBgYCBGjx4NmUyGrVu3FvmjoFWrVti+fTvGjx+PNm3awNjYGD179kSPHj2wa9cu+Pv74+2330ZsbCxWr14Nd3d3pKWlqfw9EhMT8cYbb6BOnTq4c+cOVq5ciebNmytbCSdNmoQ9e/agR48eyilW0tPTceXKFezYsQO3b9+GtbV1mY8HvYRGrsGjKuuff/4Rw4YNE87OzkJfX1+YmJgILy8vsXLlSpVLaHNyckRISIhwcXERenp6wtHRscRJKV/UuXNn0blzZ+Xj4qYOECJ/ssmmTZsKfX190bBhQ/Hdd98VmjogPDxcvPvuu8LBwUHo6+sLBwcHERAQoHL5bXGTUh46dEh4eXkJQ0NDYWpqKnr27FnspJQvTk1Q2lsnFExK+aLijg9euPT+2bNnYtCgQcLa2loYGxsLX19fcePGjSIv+V+7dq1wdXUVurq6RU5KWZT/1nPv3j1hZmYmevbsWWg9f39/UbNmTXHr1q0SX++L8RcomJTS3NxcGBgYiNdee63YSSlLugT/v0o6d1DEpdUxMTFiwIABws7OTujp6YnatWuLHj16iB07dhTa3tbWVgBQmZzz5MmTAoDo2LGjyrq3bt0SgwcPFvXq1VNOHNq1a1dx6NAhlfXS09PFyJEjhaWlpTA2Nha9evUSUVFRAoBYuHChcr3izjkhSv/+y8vLE1OmTBHW1tbCyMhI+Pr6iujo6JdOSmlhYSGMjY1F//79VabVKE5ubq4YNWqUsLGxETKZrNA0AmvWrBGtWrUShoaGwsTERHh4eIjJkyeLhw8fCiGEuHDhgggICBB169ZVTlzZo0cPcf78eZV6Tp8+LVq1aiX09fVLddn85cuXRefOnV86KeWpU6fE66+/LgwNDYWDg4OYPHmycgqP/07DkZaWJv73v/8Jc3NzlUkpFQqFmD9/vnBychJyuVy0aNFC7N27t9DUJzt27BA+Pj7C1tZW6Ovri7p164qPP/5YxMXFqcSdmpoqpk2bJtzc3IS+vr6wtrYW7du3F1999ZXK1A5lPR5UPJkQr9hmTkREFeLSpUto0aIFvvvuuyIvbS9vBZNG/vnnn7yBNVVLHLNERFSJPH/+vFDZsmXLoKOjozLAmIgqDscsERFVIosWLcJff/2Frl27okaNGspLyIcPH15ozi0iqhhMloiIKpH27dsjLCwMc+bMQVpaGurWrYvg4GBMnz5d06ERVVscs0RERERUAo5ZIiIiIioBkyUiIiKiEnDMEr2UQqHAw4cPYWJiwin0iYiqGCEEUlNT4eDgUK6Tu2ZmZiI7O1uSuvT19WFgYCBJXVJgskQv9fDhQ16FQ0RUxd27d++Vb9j8MpmZmXBxMsajJ9LchNnOzg6xsbGVJmFiskQvZWJiAgC4c8EZpsbsua0I/g08NB1CtaNraqLpEKqVvJRUTYdQbeQiByexT/lZXh6ys7Px6EkeYv9ygqmJet8TKakKuLS6g+zsbCZLVHUUdL2ZGuuo/Sag0qkh09N0CNWOrkxf0yFUKzKe4xXn/695r4hhFKYm2vk9wWSJiIiIJJEnFMhTc0KiPKGQJhgJMVkiIiIiSSggoIB62ZK625cH7WsrIyIiIpIQW5aIiIhIEgoooG4nmvo1SI/JEhEREUkiTwjkqXkXNXW3Lw9MloiIiEgSHLNEREREVA2xZYmIiIgkoYBAnha2LDFZIiIiIkmwG46IiIioGmLLEhEREUmCV8MRERERlUDx/4u6dVQ27IYjIiIiKgFbloiIiEgSeRJcDafu9uWByRIRERFJIk/kL+rWUdmwG46IiIioBGxZIiIiIklo6wBvJktEREQkCQVkyINM7ToqGyZLREREJAmFyF/UraOy4ZglIiIiohKwZYmIiIgkkSdBN5y625cHJktEREQkCW1NltgNR0RERFQCtiwRERGRJBRCBoVQ82o4NbcvD0yWiIiISBLshiMiIiKqhtiyRERERJLIgw7y1GyHyZMoFikxWSIiIiJJCAnGLIlKOGaJ3XBEREREJWDLEhEREUlCWwd4M1kiIiIiSeQJHeQJNccsVcJ7wzFZIiIiIkkoIINCzRE+ClS+bIljloiIiIhKwJYlIiIikgTHLBERERGVQJoxS+yGIyIiIqpS2LJEREREksgf4K3mjXTZDUdERETaSiHB7U54NVw1IZPJsHv3bk2HUS38uNIWo/waoFd9D7zv0QTBg1xwL1pe5LpCANP7u8LXoTlO/2FWwZFqv54DE7A54hp+u3UZy/feRMPmGZoOSWs1bZ2MWaF/Y+vxCOy7cQLtvBM0HVK1wHO8+mKyVA7i4uLg5+en6TAKOXr0KGQyGZKSkjQdimQunzFGz4EJWLb3Jhb8GIO8XOCzgHrIzCh8av+y1gayyte6qxU6v/MMw2c9xPdL7DDStwFuXTPAvG23YGaVo+nQtJKBYR5ib9TEN7PraTqUaoPneOkUDPBWd6lsKl9EWsDOzg5yedGtG68iJ4dvxuLM33YLPh8kwrlhJuo1ycSEZXfx5IE+bl42VFkv5qohdn5rg/FL7mooUu3We3gC9m+zxMHtlrh70wArptRB1nMZfAMSNR2aVjp/whJbljvjzCFrTYdSbfAcLx0FdCRZKpvKF1ElsmPHDnh4eMDQ0BBWVlbo1q0b0tPTAQAbNmxAkyZNIJfLYW9vj6CgIOV2L+uGUygUWLRoEdzc3CCXy1G3bl3MmzcPAHD79m3IZDJs374dnTt3hoGBAdasWQNTU1Ps2LFDpZ7du3ejZs2aSE1NVW73448/on379jAwMEDTpk1x7NgxZb1du3YFAFhYWEAmk2HgwIESHq3KIT1FFwBgYp6nLMvMkGHhSCeMnHcflra5mgpNa9XQU6B+swxcOGGiLBNChosnTODeit0UVPXxHCcO8C5GXFwcAgICsGjRIvj7+yM1NRUnTpyAEAKhoaEYP348Fi5cCD8/PyQnJ+PUqVOlrnvatGlYu3Ytli5dig4dOiAuLg43btxQWWfq1KlYvHgxWrRoAQMDA0RGRmLjxo3o27evcp2CxyYmJnj69CkAYNKkSVi2bBnc3d2xZMkS9OzZE7GxsXB0dMTOnTvRp08fREVFwdTUFIaGqq0vBbKyspCVlaV8nJKSUpZDpzEKBbB6Vm00aZMG50aZyvJvg2vDvXU62r9VNV5HVWNqmQfdGkBSvOrHybOEGnB0yypmK6Kqg+d46eUJGfKEmpNSqrl9eWCyVIy4uDjk5uaid+/ecHJyAgB4eHgAAObOnYsJEyZgzJgxyvXbtGlTqnpTU1OxfPlyrFq1CoGBgQCAevXqoUOHDirrjR07Fr1791Y+Hjp0KNq3b4+4uDjY29vjyZMn2LdvHw4dOqSyXVBQEPr06QMACA0Nxf79+7F+/XpMnjwZlpaWAABbW1uYm5sXG+OCBQsQEhJSqtdTmaz6rA7u3DDE4t03lWVnDpji0ikTfHMwSoORERFVD3kSXA2Xx6vhqg5PT094e3vDw8MD7733HtauXYtnz57hyZMnePjwIby9vV+p3uvXryMrK+ul27du3Vrl8WuvvYYmTZpg8+bNAIDvvvsOTk5O6NSpk8p67dq1U/6/Ro0aaN26Na5fv16mGKdNm4bk5GTlcu/evTJtrwmrPquNiDBTLNoRDRuHf8d4XTplgrjb+ujdyAN+jp7wc/QEAMwZ5oxJfdw0Fa5WSUnURV4uYG6j2sVpYZ2LZ/H8PUZVH8/x0lMIHUmWyqbyRVRJ6OrqIiwsDH/88Qfc3d2xcuVKNGzYEI8fP1ar3uK6vl5Us2bNQmVDhw7Fpk2bAOR3wQ0aNAiycri8Sy6Xw9TUVGWprITIT5RO7zfDop+jYVc3W+X5D4IeY3V4FELD/l0A4OPgB5iwlIO9pZCbo4Obl43QokOqskwmE2jeIQ3X/jLSYGRE0uA5TkyWSiCTyeDl5YWQkBBcvHgR+vr6CAsLg7OzM8LDw1+pzvr168PQ0PCVtv/www9x584drFixAteuXVN24/3X2bNnlf/Pzc3FX3/9hcaNGwMA9PX1AQB5eXmFtquqVn1WB4d3WWLq13dgaKxA4pMaSHxSA1nP85NIS9tcODfKVFkAwLZ2TqHEil7drjXW8PtfIrq9lwhHt0yMWngfBkYKHPzRUtOhaSUDozy4NkqDa6M0AECtOllwbZQGG/vMl2xJr4rneOkUdMOpu1Q2bD8sRkREBMLDw+Hj4wNbW1tEREQgPj4ejRs3RnBwMEaMGAFbW1v4+fkhNTUVp06dwqhRo4qsy9vbG/7+/ggKCoKBgQGmTJmCyZMnQ19fH15eXoiPj8fff/+NIUOGlBiThYUFevfujUmTJsHHxwd16tQptM7XX3+N+vXro3Hjxli6dCmePXuGwYMHAwCcnJwgk8mwd+9edO/eHYaGhjA2Nlb/YGnQ3s35l05P6lNfpXzC0rvw+YCX9FaUY3ssYGaVhwGTHsHCJhe3/jbE9P4uSErQ03RoWql+01R8seWK8vHwabcAAGG/2GLptIaaCkur8RwvHQXUH6CtkCYUSTFZKoapqSmOHz+OZcuWISUlBU5OTli8eLFyssnMzEwsXboUEydOhLW1tcpVai+KiYlBQsK/M+zOmDEDNWrUwMyZM/Hw4UPY29tjxIgRpYpryJAh2LZtmzIBetHChQuxcOFCXLp0CW5ubtizZw+srfMTitq1ayMkJARTp07FoEGDMGDAAGW3XlV14OGlCtmGXm7PRmvs2ch5fyrClXPm6N6oo6bDqHZ4jldfMiFE5Rt2TsXaunUrxo0bh4cPHyq71YD8eZRcXFxw8eJFNG/eXNJ9pqSkwMzMDM/+cYWpSeVrHtVGvg7NNR1CtaNbicfmaaO8KjIliTbIFTk4il+RnJxcbmNQC74nQi+0gaGxeu0wz9Ny8UnLP8s13rJiy1IVkZGRgbi4OCxcuBAff/yxSqJERERUGUhxuxLe7oRe2aJFi9CoUSPY2dlh2rRpmg6HiIio2mDLUhURHByM4ODgYp93dnYGe1SJiEiTFJBBAXUHeHMGbyIiItJS7IYjIiIiKkFFz7O0YMECtGnTBiYmJrC1tUWvXr0QFaV6e6vMzEyMHDkSVlZWMDY2Rp8+fco8wTSTJSIiIqqSjh07hpEjR+Ls2bMICwtDTk4OfHx8kJ6erlxn3Lhx+O233/Dzzz/j2LFjePjwocq9V0uD3XBEREQkCYWQQaHupJRl2H7//v0qjzdt2gRbW1v89ddf6NSpE5KTk7F+/Xps27YNb7zxBoD824U1btwYZ8+exeuvv16q/TBZIiIiIkkoJLhdieL/t095YS4uuVwOuVxe4rbJyckAAEvL/NvQ/PXXX8jJyUG3bt2U6zRq1Ah169bFmTNnSp0ssRuOiIiIKh1HR0eYmZkplwULFpS4vkKhwNixY+Hl5YWmTZsCAB49egR9fX2Ym5urrFurVi08evSo1LGwZYmIiIgkoRA6UKh5NVvB9vfu3VOZwftlrUojR47E1atXcfLkSbX2XxQmS0RERCSJPMiQp+Y8SQXbm5qalvp2J0FBQdi7dy+OHz+ucpN5Ozs7ZGdnIykpSaV16fHjx7Czsyt1TOyGIyIioipJCIGgoCD88ssvOHz4MFxcXFSeb9WqFfT09BAeHq4si4qKwt27d9GuXbtS74ctS0RERCQJKbvhSmPkyJHYtm0bfv31V5iYmCjHIZmZmcHQ0BBmZmYYMmQIxo8fD0tLS5iammLUqFFo165dqQd3A0yWiIiISCJ5gATdcKUXGhoKAOjSpYtK+caNGzFw4EAAwNKlS6Gjo4M+ffogKysLvr6++Oabb8oUE5MlIiIiqpJKc09UAwMDfP311/j6669feT9MloiIiEgSFd0NV1GYLBEREZEktPVGukyWiIiISBICMijUHLMk1Ny+PFS+9I2IiIioEmHLEhEREUmC3XBEREREJVAIGRRCvW40dbcvD5UvfSMiIiKqRNiyRERERJLIgw7y1GyHUXf78sBkiYiIiCTBbjgiIiKiaogtS0RERCQJBXSgULMdRt3tywOTJSIiIpJEnpAhT81uNHW3Lw+VL30jIiIiqkTYskRERESS0NYB3kyWiIiISBJC6ECh5gzcgjN4ExERkbbKgwx5at4IV93ty0PlS9+IiIiIKhG2LBEREZEkFEL9MUcKIVEwEmKyRERERJJQSDBmSd3ty0Pli4iIiIioEmHLEhEREUlCARkUag7QVnf78sBkiYiIiCTBGbyJiIiIqiG2LFGp9X23N2royjUdRrXQ4++zmg6h2tnbRNMRVC81HOtoOoTqQ5EF3K+gXWnpAG8mS0RERCQJBSS43UklHLNU+dI3IiIiokqELUtEREQkCSHB1XCiErYsMVkiIiIiSSiEBN1wlfBqOCZLREREJAltHeBd+SIiIiIiqkTYskRERESSYDccERERUQm09XYn7IYjIiIiKgFbloiIiEgS7IYjIiIiKoG2JkvshiMiIiIqAVuWiIiISBLa2rLEZImIiIgkoa3JErvhiIiIiErAliUiIiKShID68yQJaUKRFJMlIiIikoS2dsMxWSIiIiJJaGuyxDFLRERERCVgyxIRERFJQltblpgsERERkSS0NVliNxwRERFRCdiyRERERJIQQgahZsuQutuXByZLREREJAkFZGrPs6Tu9uWB3XBEREREJWDLEhEREUlCWwd4M1kiIiIiSWjrmCV2wxERERGVgC1LREREJAl2wxERERGVQFu74ZgsERERkSSEBC1LlTFZ4pglIiIiohKwZYmIiIgkIQAIoX4dlQ2TJSIiIpKEAjLIOIM3ERERUfXCliUiIiKSBK+GIyIiIiqBQsgg08J5ltgNR0RERFQCtiwRERGRJISQ4Gq4Sng5HJMlIiIikoS2jlliNxwRERFRCapky5JMJsMvv/yCXr16vdL2R48eRdeuXfHs2TOYm5tLGltFUfcYaLPuPaLxds8Y1KqVDgC4c8cMP3znjvN/2ms4Mu0QvdYAcWF6SIvVha6BgEXzXDQe/xzGLgrlOnlZwLVFhnj4hz4U2TLYeOXAY0YG5NaVsH29iuo5MAF9P3kCS5tc3LpmiG8+r42oS0aaDksrvRcYjfZdHqGOUxqys3Rx/YoFNq5qhAd3jTUdWqXDlqVKJC4uDn5+fpoOQ+no0aOQyWRISkqqsH1WtmNQmSQkGGHj+mYYPfJNjBn5JiIv2WJGyCnUdUrWdGha4emfNeAckIUOP6Tg9bVpELkyRAwzRm7Gv+tc+8IIj4/qo9WSdLTbnIrMeB2cH8MvFql0fucZhs96iO+X2GGkbwPcumaAedtuwcwqR9OhaSWPFon4fYcTJgzxwuej26JGDQXmrjgHuUGupkOrdBT/f284dZeyOH78OHr27AkHBwfIZDLs3r1b5fmBAwdCJpOpLG+99VaZ9lElkyU7OzvI5XJNh1Fm2dnZktVVVY9BRTh31gHnz9nj4QMTPHhggi0bPZD5vAYaNX6q6dC0Qts1aXD0z4aJmwKmjfLgOS8dz+N0kXwtv6E6JxW4u1Mf7pMzYP16Lsyb5KH53HQ8u1QDzyJ1NRy9dug9PAH7t1ni4HZL3L1pgBVT6iDruQy+AYmaDk0rzRz7Gg797oi7sSaIvWmKJbM9YWv/HG6N+APsRQUDvNVdyiI9PR2enp74+uuvi13nrbfeQlxcnHL54YcfyrQPjSZLO3bsgIeHBwwNDWFlZYVu3bohPT2/62TDhg1o0qQJ5HI57O3tERQUpNyuqMzxvxQKBRYsWAAXFxcYGhrC09MTO3bsKDGWkydPomPHjjA0NISjoyNGjx6tjAUAsrKyMGXKFDg6OkIul8PNzQ3r16/H7du30bVrVwCAhYUFZDIZBg4cCADo0qULgoKCMHbsWFhbW8PX1xcAcOzYMbz22mvK1zZ16lTk5v77C6VLly4YPXo0Jk+eDEtLS9jZ2SE4OFgl3hePwf379xEQEABLS0vUrFkTrVu3RkREBAAgMjISXbt2hYmJCUxNTdGqVSucP3++xOOhLXR0FOjU5S4MDHJx/ZqVpsPRSrmp+b8C9czyu+GS/64BkSuDTbt/z2ljVwUM7fPw7FKV7PmvVGroKVC/WQYunDBRlgkhw8UTJnBvlVHCliSVmsb553Zair6GIyEA8PPzw9y5c+Hv71/sOnK5HHZ2dsrFwsKiTPvQ2CdXXFwcAgICsGjRIvj7+yM1NRUnTpyAEAKhoaEYP348Fi5cCD8/PyQnJ+PUqVOlrnvBggX47rvvsHr1atSvXx/Hjx/Hhx9+CBsbG3Tu3LnQ+jExMXjrrbcwd+5cbNiwAfHx8QgKCkJQUBA2btwIABgwYADOnDmDFStWwNPTE7GxsUhISICjoyN27tyJPn36ICoqCqampjA0NFTWvXnzZnzyySfK+B88eIDu3btj4MCB2LJlC27cuIFhw4bBwMBAJSHavHkzxo8fj4iICJw5cwYDBw6El5cX3nzzzULxp6WloXPnzqhduzb27NkDOzs7XLhwAQpF/pdX//790aJFC4SGhkJXVxeXLl2Cnp5esccvKysLWVlZyscpKSmlPvaVhbNzEhavOAx9/Tw8f14Dc0K8cO+umabD0jpCAfz9hSEsWuTCtH7++ZaVIIOOnoCeqerPQ30rgayEKtmYXamYWuZBtwaQFK/68f0soQYc3bKK2YqkIpMJDB93DX9HWuDOLZOXb1DN5LcMqTtmKf/fF7975HL5K/eoHD16FLa2trCwsMAbb7yBuXPnwsqq9D+gNZos5ebmonfv3nBycgIAeHh4AADmzp2LCRMmYMyYMcr127RpU6p6s7KyMH/+fBw6dAjt2rUDALi6uuLkyZP49ttvi0yWFixYgP79+2Ps2LEAgPr162PFihXo3LkzQkNDcffuXfz0008ICwtDt27dlHUWsLS0BADY2toWGjBev359LFq0SPl4+vTpcHR0xKpVqyCTydCoUSM8fPgQU6ZMwcyZM6Gjk/9l0qxZM8yaNUtZx6pVqxAeHl5ksrRt2zbEx8fjzz//VMbi5uamfP7u3buYNGkSGjVqpKyvJAsWLEBISEiJ61R29++bIGjEm6hZMwcdOt7HhEnnMHlCFyZMErs61wipN3XRfmuqpkMhqhCfTLoKJ9dUTPq4naZDqZSkHODt6OioUj5r1qxCvSyl8dZbb6F3795wcXFBTEwMPvvsM/j5+eHMmTPQ1S3d0ACNJUuenp7w9vaGh4cHfH194ePjg759+yInJwcPHz6Et7f3K9UbHR2NjIyMQklFdnY2WrRoUeQ2kZGRuHz5Mr7//ntlmRACCoUCsbGxuHLlCnR1dYtMtF6mVatWKo+vX7+Odu3aQSb792Ty8vJCWloa7t+/j7p16wLIT5b+y97eHk+ePClyH5cuXUKLFi2UidKLxo8fj6FDh2Lr1q3o1q0b3nvvPdSrV6/YmKdNm4bx48crH6ekpBQ6aSu73FxdxD3M/9UXfdMS9Rsm4l3/m1i1vLWGI9MeV+Ya4vExPbTfnApDu39bkeTWAoocGXJSZCqtS9lPZZBbK4qqisogJVEXebmAuY3q4GIL61w8i2c3Z3kaMfEqXuvwBFM+boenTwxfvgGp5d69ezA1NVU+ftVWpX79+in/7+HhgWbNmqFevXo4evRoqXMNjbWJ6+rqIiwsDH/88Qfc3d2xcuVKNGzYEI8fP1ar3rS0NADA77//jkuXLimXa9euFTtuKS0tDR9//LHK+pGRkbh58ybq1aun0q1WVjVr1nyl7V7sJpPJZMputRe9LL7g4GD8/fffePvtt3H48GG4u7vjl19+KXZ9uVwOU1NTlaWq05EBevr8opaCEPmJ0qNwfby+IRVGdVSPq1mTXMhqCCSc/feLOy1WB8/jdGHRnFcPqSs3Rwc3LxuhRYd/W/NkMoHmHdJw7S9OHVA+BEZMvIp2nR/hs5Gv43Ecj3NxhEQLgELfQ1Jd1OTq6gpra2tER0eXehuN/gyRyWTw8vKCl5cXZs6cCScnJ4SFhcHZ2Rnh4eHKgdNl4e7uDrlcjrt375a6Jahly5a4du2aStfVf3l4eEChUODYsWPKbrj/0tfPH+SXl5f30n01btwYO3fuhBBC2bp06tQpmJiYoE6dOqWK90XNmjXDunXrkJiYWGzrUoMGDdCgQQOMGzcOAQEB2LhxY4mD4aqygYMv4/yf9njyxAhGhjno8sZdeHg+wYxpnTQdmla4OscQD/bpo83KdNQwEsiM//8B3iYCugaAnglQt082ri0yhJ6ZQA1jgb/nG8GieS4sPF/+HqGX27XGGhOX3cM/kUaIumgE/2HxMDBS4OCPRb//ST2fTrqKzr4PMWdSazxP14WFZSYAID1dD9lZvMLzv6rCPEv379/H06dPYW9f+rn3NJYsRUREIDw8HD4+PrC1tUVERATi4+PRuHFjBAcHY8SIEbC1tYWfnx9SU1Nx6tQpjBo1qsi6vL294e/vj6CgIJiYmGDixIkYN24cFAoFOnTooBwgbmpqisDAwELbT5kyBa+//jqCgoIwdOhQ1KxZE9euXUNYWBhWrVoFZ2dnBAYGYvDgwcoB3nfu3MGTJ0/w/vvvw8nJCTKZDHv37kX37t1haGgIY+Oi55T59NNPsWzZMowaNQpBQUGIiorCrFmzMH78eOV4pbIKCAjA/Pnz0atXLyxYsAD29va4ePEiHBwc0Lx5c0yaNAl9+/aFi4sL7t+/jz///BN9+vR5pX1VBWbmWZgwOQKWlplIT9dDbKwZZkzrhIsX7DQdmla4s90AAHBmoOrgVs+56XD0z58ew31KBiAzxF9ja0KRkz8pZdPPeaWWVI7tsYCZVR4GTHoEC5tc3PrbENP7uyApofgLN+jVvd33LgDgi9VnVcqXzm6GQ79XrSEK2igtLU2llSg2NhaXLl2CpaUlLC0tERISgj59+sDOzg4xMTGYPHky3NzclFeol4bGkiVTU1McP34cy5YtQ0pKCpycnLB48WLlRIuZmZlYunQpJk6cCGtra/Tt27fYumJiYpCQkKB8PGfOHNjY2GDBggW4desWzM3N0bJlS3z22WdFbt+sWTMcO3YM06dPR8eOHSGEQL169fDBBx8o1wkNDcVnn32GTz/9FE+fPkXdunWV9dWuXRshISGYOnUqBg0ahAEDBmDTpk1F7qt27drYt28fJk2aBE9PT1haWmLIkCH4/PPPy3oIlfT19XHw4EFMmDAB3bt3R25uLtzd3fH1119DV1cXT58+xYABA/D48WNYW1ujd+/eVX4Ad0mWLyndxQD0anr8/eyl6+jKAY8Zz+Ex43kFRFQ97dlojT0brTUdRrXwdtu3NR1C1fHffjR16iiD8+fPq/REFYy5DQwMRGhoKC5fvozNmzcjKSkJDg4O8PHxwZw5c8rUrScTojLe35cqk5SUFJiZmcG78UTU0OVEmBXB76ezL1+JJLW3SdnmXSH11HB8tWEHVHa5iiwcuh+K5OTkchuDWvA94bppOnSMDNSqS5GRiVsD55VrvGXFSU+IiIiISsDrTImIiEgSr3K7kqLqqGyYLBEREZEkqsLVcK+CyRIRERFJQ8jyF3XrqGQ4ZomIiIioBGxZIiIiIklwzBIRERFRSTQwz1JFYDccERERUQlK1bK0Z8+eUlf4zjvvvHIwREREVHVV66vhevXqVarKZDJZqW4mS0RERFqqEnajqatUyZJCoSjvOIiIiIgqJbUGeGdmZsLAQL17wBAREZF20NZuuDIP8M7Ly8OcOXNQu3ZtGBsb49atWwCAGTNmYP369ZIHSERERFWEkGipZMqcLM2bNw+bNm3CokWLoK+vryxv2rQp1q1bJ2lwRERERJpW5mRpy5YtWLNmDfr37w9dXV1luaenJ27cuCFpcERERFSVyCRaKpcyj1l68OAB3NzcCpUrFArk5ORIEhQRERFVQZyUMp+7uztOnDhRqHzHjh1o0aKFJEERERFRFaSlY5bK3LI0c+ZMBAYG4sGDB1AoFNi1axeioqKwZcsW7N27tzxiJCIiItKYMrcsvfvuu/jtt99w6NAh1KxZEzNnzsT169fx22+/4c033yyPGImIiKgqEDJplkrmleZZ6tixI8LCwqSOhYiIiKowIfIXdeuobF55Usrz58/j+vXrAPLHMbVq1UqyoIiIiIgqizInS/fv30dAQABOnToFc3NzAEBSUhLat2+PH3/8EXXq1JE6RiIiIqoKeDVcvqFDhyInJwfXr19HYmIiEhMTcf36dSgUCgwdOrQ8YiQiIqKqgGOW8h07dgynT59Gw4YNlWUNGzbEypUr0bFjR0mDIyIiItK0MidLjo6ORU4+mZeXBwcHB0mCIiIioqpHJvIXdeuobMrcDffll19i1KhROH/+vLLs/PnzGDNmDL766itJgyMiIqIqpDpPSmlhYQGZ7N8+xPT0dLRt2xY1auRvnpubixo1amDw4MHo1atXuQRKREREpAmlSpaWLVtWzmEQERFRlSfFAO2qOsA7MDCwvOMgIiKiqk5Lpw545UkpASAzMxPZ2dkqZaampmoFRERERFWUliZLZR7gnZ6ejqCgINja2qJmzZqwsLBQWYiIiIi0SZmTpcmTJ+Pw4cMIDQ2FXC7HunXrEBISAgcHB2zZsqU8YiQiIqKqoDpfDfdfv/32G7Zs2YIuXbpg0KBB6NixI9zc3ODk5ITvv/8e/fv3L484iYiIqLLT0gHeZW5ZSkxMhKurK4D88UmJiYkAgA4dOuD48ePSRkdERESkYWVOllxdXREbGwsAaNSoEX766ScA+S1OBTfWJSIiouqnYAZvdZfKpszJ0qBBgxAZGQkAmDp1Kr7++msYGBhg3LhxmDRpkuQBEhERURXBMUv5xo0bp/x/t27dcOPGDfz1119wc3NDs2bNJA2OiIiISNPUmmcJAJycnODk5CRFLERERESVTqmSpRUrVpS6wtGjR79yMERERFR1yaD+mKPKdy1cKZOlpUuXlqoymUzGZEmL5V2/CZlMT9NhVAt/tGNrbUU78JBX81YkXwdNR1B95IocTYdQ5ZUqWSq4+o2IiIioWFo6z5LaY5aIiIiIAGjtveGYLBEREZE0tDRZKvM8S0RERETVCVuWiIiISBJSzMBdGWfwZrJERERE0mA33L9OnDiBDz/8EO3atcODBw8AAFu3bsXJkyclDY6IiIhI08qcLO3cuRO+vr4wNDTExYsXkZWVBQBITk7G/PnzJQ+QiIiIqggtvTdcmZOluXPnYvXq1Vi7di309P6doNDLywsXLlyQNDgiIiKqOgrGLKm7VDZlTpaioqLQqVOnQuVmZmZISkqSIiYiIiKiSqPMyZKdnR2io6MLlZ88eRKurq6SBEVERERVUMEM3uoulUyZk6Vhw4ZhzJgxiIiIgEwmw8OHD/H9999j4sSJ+OSTT8ojRiIiIqoKtHTMUpmnDpg6dSoUCgW8vb2RkZGBTp06QS6XY+LEiRg1alR5xEhERESkMWVOlmQyGaZPn45JkyYhOjoaaWlpcHd3h7GxcXnER0RERFUEJ6V8gb6+Ptzd3aWMhYiIiKoyLZ2UsszJUteuXSGTFT/46vDhw2oFRERERFWUFJf+a0Oy1Lx5c5XHOTk5uHTpEq5evYrAwECp4iIiIiKqFMqcLC1durTI8uDgYKSlpakdEBEREVVRWtoN90r3hivKhx9+iA0bNkhVHREREVU1Wjp1gGTJ0pkzZ2BgYCBVdURERESVQpm74Xr37q3yWAiBuLg4nD9/HjNmzJAsMCIiIqpaOHXA/zMzM1N5rKOjg4YNG2L27Nnw8fGRLDAiIiKiyqBMyVJeXh4GDRoEDw8PWFhYlFdMRERERJVGmcYs6erqwsfHB0lJSeUUDhEREVVZHOCdr2nTprh161Z5xEJERERVWMGYJXWXyqbMydLcuXMxceJE7N27F3FxcUhJSVFZiIiIiLRJqZOl2bNnIz09Hd27d0dkZCTeeecd1KlTBxYWFrCwsIC5uTnHMREREVV3FdwFd/z4cfTs2RMODg6QyWTYvXu3ajhCYObMmbC3t4ehoSG6deuGmzdvlmkfpR7gHRISghEjRuDIkSNl2gERERFVExqYwTs9PR2enp4YPHhwoemNAGDRokVYsWIFNm/eDBcXF8yYMQO+vr64du1aqeeHLHWyJER+9J07dy7tJkRERFSNaGKeJT8/P/j5+RX5nBACy5Ytw+eff453330XALBlyxbUqlULu3fvRr9+/Uq1jzKNWZLJZGVZnYiIiOiVvDgmOisrq8x1xMbG4tGjR+jWrZuyzMzMDG3btsWZM2dKXU+Z5llq0KDBSxOmxMTEslRJRERE2kLCbjhHR0eV4lmzZiE4OLhMVT169AgAUKtWLZXyWrVqKZ8rjTIlSyEhIYVm8CYiIiICpO2Gu3fvHkxNTZXlcrlcvYrVUKZkqV+/frC1tS2vWIiIiIgAAKampirJ0quws7MDADx+/Bj29vbK8sePH6N58+alrqfUY5Y4XomIiIhKVMlm8HZxcYGdnR3Cw8OVZSkpKYiIiEC7du1KXU+Zr4YjIiIiKpIGpg5IS0tDdHS08nFsbCwuXboES0tL1K1bF2PHjsXcuXNRv3595dQBDg4O6NWrV6n3UepkSaFQlCl4IiIiovJ2/vx5dO3aVfl4/PjxAIDAwEBs2rQJkydPRnp6OoYPH46kpCR06NAB+/fvL/UcS0AZxywRERERFUcT8yx16dKlxN4vmUyG2bNnY/bs2a8cE5MlIiIikoYGuuEqQplvpEtERERUnbBliYiIiKShpS1LTJZIK/UcmIC+nzyBpU0ubl0zxDef10bUJSNNh6WVmrZORp8h9+HWJA1WttmYM7IxzoRbazosrfHjSluc2meOe9Fy6Bso4N46A0OmP4SjW+FbPwgBfP6hK84fMcWs9bFo75esgYi1Fz9XXk4TY5YqArvhKohMJsPu3bs1HQaA/MFwY8eO1XQY5abzO88wfNZDfL/EDiN9G+DWNQPM23YLZlY5mg5NKxkY5iH2Rk18M7uepkPRSpfPGKPnwAQs23sTC36MQV4u8FlAPWRmFP74/mWtDTglXvng50opVbJ5lqTCZKmCxMXFFXtXZJJW7+EJ2L/NEge3W+LuTQOsmFIHWc9l8A3gfQvLw/kTltiy3BlnDrE1qTzM33YLPh8kwrlhJuo1ycSEZXfx5IE+bl42VFkv5qohdn5rg/FL7mooUu3Gz5XqjclSBbGzs9PofW2qixp6CtRvloELJ0yUZULIcPGECdxbZWgwMiJppKfoAgBMzPOUZZkZMiwc6YSR8+7D0jZXU6FpLX6ulF5BN5y6S2XDZKmMduzYAQ8PDxgaGsLKygrdunVDeno6AGDDhg1o0qQJ5HI57O3tERQUpNzuZd1wXbp0wahRozB27FhYWFigVq1aWLt2LdLT0zFo0CCYmJjAzc0Nf/zxh8p2V69ehZ+fH4yNjVGrVi189NFHSEhIUD6fnp6OAQMGwNjYGPb29li8eLG0B6SSMbXMg24NICledTjes4QasLDhlwhVbQoFsHpWbTRpkwbnRpnK8m+Da8O9dTrav5Wiwei0Fz9XyoDdcBQXF4eAgAAMHjwY169fx9GjR9G7d28IIRAaGoqRI0di+PDhuHLlCvbs2QM3N7cy1b9582ZYW1vj3LlzGDVqFD755BO89957aN++PS5cuAAfHx989NFHyMjI/yWTlJSEN954Ay1atMD58+exf/9+PH78GO+//76yzkmTJuHYsWP49ddfcfDgQRw9ehQXLlwoMY6srCykpKSoLESkeas+q4M7NwwxLfSOsuzMAVNcOmWCEbMfaDAyIu3Gq+HKIC4uDrm5uejduzecnJwAAB4eHgCAuXPnYsKECRgzZoxy/TZt2pSpfk9PT3z++ecAgGnTpmHhwoWwtrbGsGHDAAAzZ85EaGgoLl++jNdffx2rVq1CixYtMH/+fGUdGzZsgKOjI/755x84ODhg/fr1+O677+Dt7Q0gPyGrU6dOiXEsWLAAISEhZYq9skhJ1EVeLmD+wq89C+tcPIvn6U5V16rPaiMizBSLf4mGjcO/g4ovnTJB3G199G7kobL+nGHOaNo2HV/ujH6xKiojfq6UAacOIE9PT3h7e8PDwwO+vr7w8fFB3759kZOTg4cPHyoTklfVrFkz5f91dXVhZWWlTMYAoFatWgCAJ0+eAAAiIyNx5MgRGBsbF6orJiYGz58/R3Z2Ntq2basst7S0RMOGDUuMY9q0acp76wD5d2h2dHR8tRdVwXJzdHDzshFadEjFmf1mAACZTKB5hzTs2WSl4eiIyk4I4OvptXF6vxm+3BENu7rZKs9/EPQYfv97qlL28RuN8HHwA7zuw1ZhKfBzpfRk/7+oW0dlw2SpDHR1dREWFobTp0/j4MGDWLlyJaZPn47w8HBJ6tfT01N5LJPJVMpk/39NcMFNjdPS0tCzZ0988cUXheqyt7dXuQtzWcjl8io9GH3XGmtMXHYP/0QaIeqiEfyHxcPASIGDP1pqOjStZGCUB4e6z5WPa9XJgmujNKQm10B8XOlvVElFW/VZHRz5xQLBG2/B0FiBxCf5H9s1TfIgNxSwtM0tclC3be2cQokVvTp+rlRvTJbKSCaTwcvLC15eXpg5cyacnJwQFhYGZ2dnhIeHq9z5uLy1bNkSO3fuhLOzM2rUKPynrFevHvT09BAREYG6desCAJ49e4Z//vkHnTt3rrA4K9qxPRYws8rDgEmPYGGTi1t/G2J6fxckJei9fGMqs/pNU/HFlivKx8On3QIAhP1ii6XTSm7FpJfbuzl/SoZJfeqrlE9Yehc+H/Cy9YrCz5VSYjccRUREIDw8HD4+PrC1tUVERATi4+PRuHFjBAcHY8SIEbC1tYWfnx9SU1Nx6tQpjBo1qsi6vL294e/vr3LFXFmNHDkSa9euRUBAACZPngxLS0tER0fjxx9/xLp162BsbIwhQ4Zg0qRJsLKygq2tLaZPnw4dHe0f179nozX2bOS8PxXhyjlzdG/UUdNhaK0DDy9VyDb0cvxceTltncGbyVIZmJqa4vjx41i2bBlSUlLg5OSExYsXKyebzMzMxNKlSzFx4kRYW1ujb9++xdYVExOjcon/q3BwcMCpU6cwZcoU+Pj4ICsrC05OTnjrrbeUCdGXX36p7K4zMTHBhAkTkJzMWyAQERGVlkwIUQlzOKpMUlJSYGZmhi54FzVkbHKuCLqmppoOodrZd+O4pkOoVnwdmms6hGojV+TgKH5FcnIyTMvps6Xge6LJx/OhK1dvrGJeVib+/vazco23rNiyRERERNLRwiYYJktEREQkCW0ds6T9I32JiIiI1MCWJSIiIpIGpw4gIiIiKh674YiIiIiqIbYsERERkTTYDUdERERUPHbDEREREVVDbFkiIiIiabAbjoiIiKgEWpossRuOiIiIqARsWSIiIiJJaOsAbyZLREREJA0t7YZjskRERESSkAkBmVAv21F3+/LAMUtEREREJWDLEhEREUmD3XBERERExdPWAd7shiMiIiIqAVuWiIiISBrshiMiIiIqHrvhiIiIiKohtiwRERGRNNgNR0RERFQ8dsMRERERVUNsWSIiIiJpsBuOiIiIqGSVsRtNXUyWiIiISBpC5C/q1lHJcMwSERERUQnYskRERESS0Nar4ZgsERERkTS0dIA3u+GIiIiISsCWJSIiIpKETJG/qFtHZcNkiYiIiKTBbjgiIiKi6octS0RERCQJXg1HREREVBJOSklERERU/bBliUpN19QEujJ9TYdRLeSlpGg6hGrH16G5pkOoVg48vKTpEKqNlFQFLBpUzL7YDUdERERUEi29Go7JEhEREUlCW1uWOGaJiIiIqARsWSIiIiJpaOnVcEyWiIiISBLshiMiIiKqhtiyRERERNLg1XBERERExWM3HBEREVE1xJYlIiIikoZC5C/q1lHJMFkiIiIiaWjpmCV2wxEREZEkZPh33NIrL2XYX3BwMGQymcrSqFEjyV8XW5aIiIioymrSpAkOHTqkfFyjhvSpDZMlIiIikoYGZvCuUaMG7Ozs1NvnS7AbjoiIiCShdhfcf6YeSElJUVmysrKK3OfNmzfh4OAAV1dX9O/fH3fv3pX8dTFZIiIiokrH0dERZmZmymXBggWF1mnbti02bdqE/fv3IzQ0FLGxsejYsSNSU1MljYXdcERERCQNCa+Gu3fvHkxNTZXFcrm80Kp+fn7K/zdr1gxt27aFk5MTfvrpJwwZMkTNQP7FZImIiIgkIRMCMjXHLBVsb2pqqpIslYa5uTkaNGiA6OhotWJ4EbvhiIiISCukpaUhJiYG9vb2ktbLZImIiIikoZBoKaWJEyfi2LFjuH37Nk6fPg1/f3/o6uoiICBAspcEsBuOiIiIJCJlN1xp3L9/HwEBAXj69ClsbGzQoUMHnD17FjY2NmrF8CImS0RERFQl/fjjjxWyHyZLREREJA0tvTcckyUiIiKShgZm8K4ITJaIiIhIEv+dgVudOiobXg1HREREVAK2LBEREZE02A1HREREVDyZIn9Rt47Kht1wRERERCVgyxIRERFJg91wRERERCXQ0nmW2A1HREREVAK2LBEREZEkKvrecBWFyRIRERFJQ0vHLLEbjoiIiKgEbFkiIiIiaQgA6s6TVPkalpgsERERkTQ4ZomIiIioJAISjFmSJBJJccwSERERUQnYskRERETS0NKr4ZgsERERkTQUAGQS1FHJsBtOTTKZDLt379Z0GPQfTVsnY1bo39h6PAL7bpxAO+8ETYdULfQcmIDNEdfw263LWL73Jho2z9B0SFqNx7t8/LjSFqP8GqBXfQ+879EEwYNccC9aXuS6QgDT+7vC16E5Tv9hVsGRUkVisqSmuLg4+Pn5aToM+g8DwzzE3qiJb2bX03Qo1Ubnd55h+KyH+H6JHUb6NsCtawaYt+0WzKxyNB2aVuLxLj+Xzxij58AELNt7Ewt+jEFeLvBZQD1kZhT+uvxlrQ1k6raiaJmCq+HUXSobJktqsrOzg1xe9K8O0ozzJyyxZbkzzhyy1nQo1Ubv4QnYv80SB7db4u5NA6yYUgdZz2XwDUjUdGhaice7/Mzfdgs+HyTCuWEm6jXJxIRld/HkgT5uXjZUWS/mqiF2fmuD8UvuaijSSqpgzJK6SyXDZOn/7dixAx4eHjA0NISVlRW6deuG9PR0AMCGDRvQpEkTyOVy2NvbIygoSLndy7rhSqp34MCB6NWrF0JCQmBjYwNTU1OMGDEC2dnZyu3379+PDh06wNzcHFZWVujRowdiYmJU9nH//n0EBATA0tISNWvWROvWrREREaF8/tdff0XLli1hYGAAV1dXhISEIDc3V4rDRoQaegrUb5aBCydMlGVCyHDxhAncW7FrSGo83hUrPUUXAGBinqcsy8yQYeFIJ4ycdx+WtvwsrQ44wBv5XWkBAQFYtGgR/P39kZqaihMnTkAIgdDQUIwfPx4LFy6En58fkpOTcerUKbXrLRAeHg4DAwMcPXoUt2/fxqBBg2BlZYV58+YBANLT0zF+/Hg0a9YMaWlpmDlzJvz9/XHp0iXo6OggLS0NnTt3Ru3atbFnzx7Y2dnhwoULUCjyR8idOHECAwYMwIoVK9CxY0fExMRg+PDhAIBZs2YVGXdWVhaysrKUj1NSUl7puFL1YGqZB90aQFK86sfJs4QacHTLKmYrelU83hVHoQBWz6qNJm3S4NwoU1n+bXBtuLdOR/u3+NlYCK+G015xcXHIzc1F79694eTkBADw8PAAAMydOxcTJkzAmDFjlOu3adNG7XoL6OvrY8OGDTAyMkKTJk0we/ZsTJo0CXPmzIGOjg769Omjsv6GDRtgY2ODa9euoWnTpti2bRvi4+Px559/wtLSEgDg5uamXD8kJARTp05FYGAgAMDV1RVz5szB5MmTi02WFixYgJCQkFK9RiIibbXqszq4c8MQi3ffVJadOWCKS6dM8M3BKA1GVolpabLEbjgAnp6e8Pb2hoeHB9577z2sXbsWz549w5MnT/Dw4UN4e3tLWu+L6xgZGSkft2vXDmlpabh37x4A4ObNmwgICICrqytMTU3h7OwMALh7N7+f/NKlS2jRooUyUXpRZGQkZs+eDWNjY+UybNgwxMXFISOj6Cb7adOmITk5WbkUxEJUlJREXeTlAuY2qt0RFta5eBbP32NS4/GuGKs+q42IMFMs2hENG4d/B85fOmWCuNv66N3IA36OnvBz9AQAzBnmjEl93Iqrjqo4JksAdHV1ERYWhj/++APu7u5YuXIlGjZsiMePH5dLvbGxsaWuo2fPnkhMTMTatWsRERGhHItUMK7J0NCwpM2RlpaGkJAQXLp0SblcuXIFN2/ehIGBQZHbyOVymJqaqixExcnN0cHNy0Zo0SFVWSaTCTTvkIZrfxmVsCW9Ch7v8iVEfqJ0er8ZFv0cDbu62SrPfxD0GKvDoxAa9u8CAB8HP8CEpRzsDYVESyXDnyH/TyaTwcvLC15eXpg5cyacnJwQFhYGZ2dnhIeHo2vXrpLV+8svv2D8+PEA8lt+nj9/rkx6zp49C2NjYzg6OuLp06eIiorC2rVr0bFjRwDAyZMnVepv1qwZ1q1bh8TExCJbl1q2bImoqCiVrjltZ2CUB4e6z5WPa9XJgmujNKQm10B8XNEJIqln1xprTFx2D/9EGiHqohH8h8XDwEiBgz8W3eJJ6uHxLj+rPquDI79YIHjjLRgaK5D4JP9rsqZJHuSGApa2uUUO6ratnVMosaqOeCNdLRYREYHw8HD4+PjA1tYWERERiI+PR+PGjREcHIwRI0bA1tYWfn5+SE1NxalTpzBq1Kgi6/L29oa/vz+CgoJKrLdAdnY2hgwZgs8//xy3b9/GrFmzEBQUBB0dHVhYWMDKygpr1qyBvb097t69i6lTp6rsLyAgAPPnz0evXr2wYMEC2Nvb4+LFi3BwcEC7du0wc+ZM9OjRA3Xr1kXfvn2ho6ODyMhIXL16FXPnzi3X46op9Zum4ostV5SPh0+7BQAI+8UWS6c11FRYWu3YHguYWeVhwKRHsLDJxa2/DTG9vwuSEvQ0HZpW4vEuP3s35085MqlPfZXyCUvvwucDTs3wUlo6ZonJEgBTU1McP34cy5YtQ0pKCpycnLB48WLlZJOZmZlYunQpJk6cCGtra/Tt27fYumJiYpCQkFCqeoH85Kp+/fro1KkTsrKyEBAQgODgYACAjo4OfvzxR4wePRpNmzZFw4YNsWLFCnTp0kW5vb6+Pg4ePIgJEyage/fuyM3Nhbu7O77++msAgK+vL/bu3YvZs2fjiy++gJ6eHho1aoShQ4dKfBQrjyvnzNG9UUdNh1Ht7NlojT0bObdVReHxLh8HHl6qkG2oapEJUQlTuGpi4MCBSEpKqvS3S0lJSYGZmRm8TT9EDZm+psOpFvI4XQNpOSYYFSclVQGLBreQnJxcbmNQC74nutUbixq66k3UnJuXhUMxy8o13rJiyxIRERFJQ0u74Xg1HBEREVEJ2LKkQZs2bdJ0CERERBKS4t5ula9lickSERERSYPdcERERETVD1uWiIiISBoKAbW70RSVr2WJyRIRERFJQyjyF3XrqGTYDUdERERUArYsERERkTS0dIA3kyUiIiKSBscsEREREZVAS1uWOGaJiIiIqARsWSIiIiJpCEjQsiRJJJJiskRERETSYDccERERUfXDliUiIiKShkIBQM1JJRWVb1JKJktEREQkDXbDEREREVU/bFkiIiIiaWhpyxKTJSIiIpKGls7gzW44IiIiohKwZYmIiIgkIYQCQqh3NZu625cHJktEREQkDSHU70bjmCUiIiLSWkKCMUuVMFnimCUiIiKiErBliYiIiKShUAAyNcccccwSERERaS12wxERERFVP2xZIiIiIkkIhQJCzW44Th1ARERE2ovdcERERETVD1uWiIiISBoKAci0r2WJyRIRERFJQwgA6k4dUPmSJXbDEREREZWALUtEREQkCaEQEGp2wwm2LBEREZHWEgppljL6+uuv4ezsDAMDA7Rt2xbnzp2T9GUxWSIiIiJJCIWQZCmL7du3Y/z48Zg1axYuXLgAT09P+Pr64smTJ5K9LiZLREREVGUtWbIEw4YNw6BBg+Du7o7Vq1fDyMgIGzZskGwfHLNEL1XQf5wrsjUcSfWRJ3I0HQJRuUpJrXyzNGurlLT8Y10RY4FyRZbaN8LNRf7nX0pKikq5XC6HXC5XKcvOzsZff/2FadOmKct0dHTQrVs3nDlzRq04/ovJEr1UamoqAOBY6k8ajoSItIVFA01HUP2kpqbCzMysXOrW19eHnZ0dTj7aJ0l9xsbGcHR0VCmbNWsWgoODVcoSEhKQl5eHWrVqqZTXqlULN27ckCQWgMkSlYKDgwPu3bsHExMTyGQyTYdTaikpKXB0dMS9e/dgamqq6XC0Ho93xeMxr1hV9XgLIZCamgoHB4dy24eBgQFiY2ORnS1ND4QQotD3zYutShWJyRK9lI6ODurUqaPpMF6Zqalplfpgq+p4vCsej3nFqorHu7xalP7LwMAABgYG5b6f/7K2toauri4eP36sUv748WPY2dlJth8O8CYiIqIqSV9fH61atUJ4eLiyTKFQIDw8HO3atZNsP2xZIiIioipr/PjxCAwMROvWrfHaa69h2bJlSE9Px6BBgyTbB5Ml0lpyuRyzZs3SaD93dcLjXfF4zCsWj3fl9MEHHyA+Ph4zZ87Eo0eP0Lx5c+zfv7/QoG91yERlnFeciIiIqJLgmCUiIiKiEjBZIiIiIioBkyUiIiKiEjBZIiIiIioBkyUiIiKiEjBZIiIiKoXMzExNh0AawmSJtMrgwYOVN/79r/T0dAwePFgDEWm3Cxcu4MqVK8rHv/76K3r16oXPPvtMsntEEWmSQqHAnDlzULt2bRgbG+PWrVsAgBkzZmD9+vUajo4qCudZIq2iq6uLuLg42NraqpQnJCTAzs4Oubm5GopMO7Vp0wZTp05Fnz59cOvWLTRp0gT+/v74888/8fbbb2PZsmWaDrHKGz9+fKnXXbJkSTlGUj3Nnj0bmzdvxuzZszFs2DBcvXoVrq6u2L59O5YtW4YzZ85oOkSqAJzBm7RCSkoKhBDKu2v/92aOeXl52LdvX6EEitT3zz//oHnz5gCAn3/+GZ06dcK2bdtw6tQp9OvXj8mSBC5evKjy+MKFC8jNzUXDhg0B5P8NdHV10apVK02Ep/W2bNmCNWvWwNvbGyNGjFCWe3p64saNGxqMjCoSkyXSCubm5pDJZJDJZGjQoEGh52UyGUJCQjQQmXYTQkChUAAADh06hB49egAAHB0dkZCQoMnQtMaRI0eU/1+yZAlMTEywefNmWFhYAACePXuGQYMGoWPHjpoKUas9ePAAbm5uhcoVCgVycnI0EBFpApMl0gpHjhyBEAJvvPEGdu7cCUtLS+Vz+vr6cHJygoODgwYj1E6tW7fG3Llz0a1bNxw7dgyhoaEAgNjYWEnvy0T5Fi9ejIMHDyoTJQCwsLDA3Llz4ePjgwkTJmgwOu3k7u6OEydOwMnJSaV8x44daNGihYaioorGZIm0QufOnQHkf0k7OjpCR4fXLlSEZcuWoX///ti9ezemT5+u/AW+Y8cOtG/fXsPRaZ+UlBTEx8cXKo+Pjy/ywgZS38yZMxEYGIgHDx5AoVBg165diIqKwpYtW7B3715Nh0cVhAO8Ses8e/YM69evx/Xr1wHk/zIcNGiQSmsTla/MzEzo6upCT09P06FolQEDBuDEiRNYvHgxXnvtNQBAREQEJk2ahI4dO2Lz5s0ajlA7nThxArNnz0ZkZCTS0tLQsmVLzJw5Ez4+PpoOjSoIkyXSKsePH0fPnj1hZmaG1q1bAwD++usvJCUl4bfffkOnTp00HKF2+fPPP6FQKNC2bVuV8oiICOjq6ir/BiSNjIwMTJw4ERs2bFCOl6lRowaGDBmCL7/8EjVr1tRwhETaickSaRUPDw+0a9cOoaGh0NXVBZB/Ndynn36K06dPq8wJROp77bXXMHnyZPTt21elfNeuXfjiiy8QERGhoci0W3p6OmJiYgAA9erVY5JUjviDgABOSklaJjo6GhMmTFAmSkD+3Evjx49HdHS0BiPTTteuXUPLli0Llbdo0QLXrl3TQETVQ1xcHOLi4lC/fn3UrFkT/M1bfkaOHIl79+4VKn/w4AFGjhypgYhIE5gskVZp2bKlcqzSf12/fh2enp4aiEi7yeVyPH78uFB5XFwcatTg9SNSe/r0Kby9vdGgQQN0794dcXFxAIAhQ4bwSrhywh8EBDBZIi0zevRojBkzBl999RVOnjyJkydP4quvvsK4ceMwbtw4XL58WbmQ+nx8fDBt2jQkJycry5KSkvDZZ5/hzTff1GBk2mncuHHQ09PD3bt3YWRkpCz/4IMPsH//fg1Gpr34g4AAjlkiLfOyKQNkMhmEEJDJZMjLy6ugqLTXgwcP0KlTJzx9+lQ558ylS5dQq1YthIWFwdHRUcMRahc7OzscOHAAnp6eMDExQWRkJFxdXXHr1i00a9YMaWlpmg5R6wQEBCAuLg6//vorzMzMAOT/IOjVqxdsbW3x008/aThCqghMi0mrxMbGajqEaqV27dq4fPkyvv/+e0RGRsLQ0BCDBg1CQEAApw0oB+np6SotSgUSExMhl8s1EJH2++qrr9CpUyc4OTkV+kGwdetWDUdHFYUtS6RV0tPTeWUQaa3u3bujVatWmDNnDkxMTHD58mU4OTmhX79+UCgU2LFjh6ZD1Erp6ekqPwiaNWvGHwTVDJMl0irGxsZ4//33MXjwYHTo0EHT4WilPXv2wM/PD3p6etizZ0+J677zzjsVFFX1cPXqVXh7e6Nly5Y4fPgw3nnnHfz9999ITEzEqVOnUK9ePU2HSKSVmCyRVtm9ezc2bdqEffv2wdnZGYMHD8aAAQN4XzgJ6ejo4NGjR7C1tS1xjBjHhZWP5ORkrFq1SmU26ZEjR8Le3l7ToWm1a9eu4e7du8jOzlYp5w+C6oHJEmml+Ph4bN26FZs2bcL169fh6+uLwYMH45133uEVLERUardu3YK/vz+uXLmivEAEyP8xAIA/CKoJJkuk9VauXIlJkyYhOzsb1tbWGDFiBKZOnVrkQFmiyi4zMxOXL1/GkydPoFAoVJ5jK4f0evbsCV1dXaxbtw4uLi44d+4cnj59igkTJuCrr75Cx44dNR0iVQAmS6SVHj9+jM2bN2PTpk24c+cO/P39MWTIENy/fx9ffPEFHBwccPDgQU2HqRXCw8MRHh5e5Jf3hg0bNBSVdtq/fz8GDBiAhISEQs+x27N8WFtb4/Dhw2jWrBnMzMxw7tw5NGzYEIcPH8aECRNw8eJFTYdIFYD9EaRVdu3ahY0bN+LAgQNwd3fHp59+ig8//BDm5ubKddq3b4/GjRtrLkgtEhISgtmzZ6N169awt7dXdk1Q+Rg1ahTee+89zJw5E7Vq1dJ0ONVCXl4eTExMAOQnTg8fPkTDhg3h5OSEqKgoDUdHFYXJEmmVgjl+Tp06hTZt2hS5joODA6ZPn17BkWmn1atXY9OmTfjoo480HUq18PjxY4wfP56JUgVq2rQpIiMj4eLigrZt22LRokXQ19fHmjVr4OrqqunwqIKwG460Rm5uLtasWYM+ffrwy6SCWFlZ4dy5c7xkvYIMHjwYXl5eGDJkiKZDqTYOHDiA9PR09O7dG9HR0ejRowf++ecfWFlZYfv27XjjjTc0HSJVACZLpFWMjIxw/fp1ODk5aTqUamHKlCkwNjbGjBkzNB1KtZCRkYH33nsPNjY28PDwKDQp4ujRozUUWfWSmJgICwsLdjtXI+yGI63y2muv4eLFi0yWKkhmZibWrFmDQ4cOoVmzZoW+vJcsWaKhyLTTDz/8gIMHD8LAwABHjx5V+bKWyWRMlsrZvXv3AID3PKyG2LJEWuWnn37CtGnTMG7cOLRq1arQrU+aNWumoci0U9euXYt9TiaT4fDhwxUYjfazs7PD6NGjMXXq1JfeNJqkkZubi5CQEKxYsUJ5o2JjY2OMGjUKs2bN4i1PqgkmS6RVivoCKZhIjpdWU1VnaWmJP//8k2PEKtAnn3yCXbt2Yfbs2WjXrh0A4MyZMwgODkavXr0QGhqq4QipIjBZIq1y586dEp9n91z5uX//PgCgTp06Go5Ee40bNw42Njb47LPPNB1KtWFmZoYff/wRfn5+KuX79u1DQEAAkpOTNRQZVSSOWSKtwmSoYikUCsydOxeLFy9WdlGYmJhgwoQJmD59OruKJJaXl4dFixbhwIEDHCNWQeRyOZydnQuVu7i4QF9fv+IDIo1gskRaZcGCBahVqxYGDx6sUr5hwwbEx8djypQpGopMO02fPh3r16/HwoUL4eXlBQA4efIkgoODkZmZiXnz5mk4Qu1y5coVtGjRAgBw9epVled4ZVb5CAoKwpw5c7Bx40bI5XIAQFZWFubNm4egoCANR0cVhd1wpFWcnZ2xbds2tG/fXqU8IiIC/fr1Q2xsrIYi004ODg5YvXp1oXuS/frrr/j000/x4MEDDUVGJA1/f3+Eh4dDLpfD09MTABAZGYns7Gx4e3urrLtr1y5NhEgVgC1LpFUePXoEe3v7QuU2NjaIi4vTQETaLTExEY0aNSpU3qhRIyQmJmogIiJpmZubo0+fPiplnDqg+mGyRFrF0dERp06dgouLi0r5qVOn4ODgoKGotJenpydWrVqFFStWqJSvWrVK+Sucyt8333yDhIQEzJw5U9OhaJ2NGzdqOgSqBJgskVYZNmwYxo4di5ycHOVtCMLDwzF58mRMmDBBw9Fpn0WLFuHtt9/GoUOHVC6rvnfvHvbt26fh6KqPnTt3IjY2lslSOXj+/DmEEDAyMgKQf8XtL7/8And3d/j4+Gg4OqooHLNEWkUIgalTp2LFihXIzs4GABgYGGDKlCn8IiknDx8+xNdff40bN24AABo3boxPP/2ULXmkFXx8fNC7d2+MGDECSUlJaNiwIfT19ZGQkIAlS5bgk08+0XSIVAGYLJFWSktLw/Xr12FoaIj69esrr2Ih6eTk5OCtt97C6tWrUb9+fU2HQ1QurK2tcezYMTRp0gTr1q3DypUrcfHiRezcuRMzZ87E9evXNR0iVQB2w5FWMjY2Rps2bTQdhlbT09PD5cuXNR2G1tuzZw/8/Pygp6eHPXv2lLjui1clkvoyMjJgYmICADh48CB69+4NHR0dvP766y+dBJe0B1uWqFrgANjyMW7cOMjlcixcuFDToWgtHR0dPHr0CLa2tiVO8snb+ZSPZs2aYejQofD390fTpk2xf/9+tGvXDn/99RfefvttPHr0SNMhUgVgskTVgre3N2JjY3Hr1i1Nh6JVRo0ahS1btqB+/fpF3riYM0pTVbdjxw7873//Q15eHry9vXHw4EEA+RPgHj9+HH/88YeGI6SKwGSJiF5Z165dS3z+yJEjFRQJUfl59OgR4uLi4OnpqWzdO3fuHExNTYucZ4y0D5MlIqIqYvTo0XBzc8Po0aNVyletWoXo6GgsW7ZMM4ERaTkmS1TlcQCs5gwePBjLly9XDoAtkJ6ejlGjRmHDhg0aikw71a5dG3v27EGrVq1Uyi9cuIB33nkH9+/f11Bk1Q/HQVYvTJaoyuMAWM3R1dVFXFwcbG1tVcoTEhJgZ2eH3NxcDUWmnQwMDHD16lW4ubmplEdHR6Np06bIzMzUUGTVD8dBVi+cOoCqPIVCUeT/qfykpKRACAEhBFJTU2FgYKB8Li8vD/v27SuUQJH63NzcsH///kJ3u//jjz/g6uqqoaiqp/DwcE2HQBWIyRIRlZm5uTlkMhlkMhkaNGhQ6HmZTIaQkBANRKbdxo8fj6CgIMTHx6vczuerr77C8uXLNRwdkfZiNxxpFQ6ArRjHjh2DEAJvvPEGdu7cCUtLS+Vz+vr6cHJy4u1OykloaCjmzZuHhw8fAgBcXFwwa9YsDBgwQMORaQ+Og6QXMVkircIBsBXrzp07qFu3LmQymaZDqRb+e1PX+Ph4PH78GGFhYXB3d4evr6+mw9MaHAdJLyr+LCCqgp4+fQozM7NC5aampkhISNBARNrt8OHD2LFjR6Hyn3/+GZs3b9ZARNrt3XffxZYtWwDk326mW7duWLJkCXr16oXQ0FANR6c9FAqFcsydQqEodmGiVH0wWSKtUjAA9kUcAFs+FixYAGtr60Lltra2mD9/vgYi0m4XLlxAx44dAeTPLF2rVi3cuXMHW7ZswYoVKzQcHZH24gBv0iocAFux7t69CxcXl0LlTk5OuHv3rgYi0m68qWvF4zhIAtiyRFpm8ODBWLx4MdavX4+uXbuia9eu+P7777F69WoMGzZM0+FpHVtbW1y+fLlQeWRkJKysrDQQkXZzc3PD7t27ce/ePRw4cAA+Pj4AgCdPnsDU1FTD0WmnnTt3wsvLq1B5+/bti+yCJu3EZIm0yvPnzxEYGIj79+/j8ePHuHz5MoKCglCrVi1Nh6aVAgICMHr0aBw5cgR5eXnIy8vD4cOHMWbMGPTr10/T4WmdmTNnYuLEiXB2dkbbtm3Rrl07APmtTC1atNBwdNqJ4yAJ4NVwpGV8fHzQu3dvjBgxAklJSWjUqBH09PSQkJCAJUuW4JNPPtF0iFolOzsbH330EX7++WfUqJHfq69QKDBgwACsXr0a+vr6Go5Q+/CmrhWradOmGDFiRKGJQFeuXInQ0FBcu3ZNQ5FRRWKyRFrF2toax44dQ5MmTbBu3TqsXLkSFy9exM6dOzFz5kxcv35d0yFqpX/++QeRkZEwNDSEh4cHnJycNB0SkSQ2bNiAoKAgTJo0qchxkOzerx44wJu0CgfAaoazszOEEKhXr56yhYlIGwwePBhZWVmYN28e5syZAyB/ItDVq1dzItBqhGOWSKtwAGzFysjIwJAhQ2BkZIQmTZoor4AbNWoUFi5cqOHoiNTHcZAEMFkiLcMBsBVr2rRpiIyMxNGjR1VuptutWzds375dg5ERSYMTgRLAZIm0TN++fXH37l2cP39eZXJKb29vLF26VIORaafdu3dj1apV6NChg8otT5o0aYKYmBgNRkYkDU4ESgDHLJEWsrOzg52dnUrZa6+9pqFotFt8fLzythD/lZ6ezvvFkVbgOEgC2LJERGpo3bo1fv/9d+XjggRp3bp1yi5QoqqM4yAJYMsSEalh/vz58PPzw7Vr15Cbm4vly5fj2rVrOH36NI4dO6bp8IjUNnPmTPzvf//DuHHj4O3tzXGQ1RTnWSIitcTExGDhwoWIjIxEWloaWrZsiSlTpsDDw0PToRFJghOBEpMlIiIiohKwG46IyiQlJaXU63JMBxFpA7YsEVGZ6OjovPRKNyEEZDIZ8vLyKigqIqLyw5YlIiqTI0eOaDoEIqIKxZYlIiIiohJwniUiUsuJEyfw4Ycfon379njw4AEAYOvWrTh58qSGIyMikgaTJSJ6ZTt37oSvry8MDQ1x4cIFZGVlAQCSk5Mxf/58DUdHRCQNJktE9Mrmzp2L1atXY+3atdDT01OWe3l54cKFCxqMjIhIOkyWiOiVRUVFoVOnToXKzczMkJSUVPEBERGVAyZLRPTK7OzsEB0dXaj85MmTcHV11UBERETSY7JERK9s2LBhGDNmDCIiIiCTyfDw4UN8//33mDhxIj755BNNh0dEJAnOs0REr2zq1KlQKBTw9vZGRkYGOnXqBLlcjokTJ2LUqFGaDo+ISBKcZ4mI1JadnY3o6GikpaXB3d0dxsbGmg6JiEgyTJaIiIiISsAxS0QkuW+++QazZ8/WdBhERJJgyxIRSc7b2xuxsbG4deuWpkMhIlIbkyUiIiKiErAbjoiIiKgEnDqAiMpkz5498PPzg56eHvbs2VPiuu+8804FRUVEVH7YDUdEZaKjo4NHjx7B1tYWOjrFN07LZDLk5eVVYGREROWDyRIRERFRCThmiYiIiKgETJaI6JWNHj0aK1asKFS+atUqjB07tuIDIiIqB0yWiOiV7dy5E15eXoXK27dvjx07dmggIiIi6TFZIqJX9vTpU5iZmRUqNzU1RUJCggYiIiKSHpMlInplbm5u2L9/f6HyP/74A66urhqIiIhIepxniYhe2fjx4xEUFIT4+Hi88cYbAIDw8HB89dVXWL58uYajIyKSBqcOICK1hIaGYt68eXj48CEAwMXFBbNmzcKAAQM0HBkRkTSYLBHRK3v+/DmEEDAyMkJ8fDweP36MsLAwuLu7w9fXV9PhERFJgmOWiOiVvfvuu9iyZQsAQE9PD926dcOSJUvQq1cvhIaGajg6IiJpMFkiold24cIFdOzYEQCwY8cO1KpVC3fu3MGWLVuKnH+JiKgqYrJERK8sIyMDJiYmAICDBw+id+/e0NHRweuvv447d+5oODoiImkwWSKiV+bm5obdu3fj3r17OHDgAHx8fAAAT548gampqYajIyKSBpMlInplM2fOxMSJE+Hs7Iy2bduiXbt2APJbmVq0aKHh6IiIpMGr4YhILY8ePUJcXBw8PT2ho5P/++vcuXMwNTVFo0aNNBwdEZH6mCwRERERlYDdcEREREQlYLJEREREVAImS0REREQlYLJEREREVAImS0RUJQwcOBC9evVSPu7SpQvGjh1b4XEcPXoUMpkMSUlJxa4jk8mwe/fuUtcZHByM5s2bqxXX7du3IZPJcOnSJbXqIaLCmCwR0SsbOHAgZDIZZDIZ9PX14ebmhtmzZyM3N7fc971r1y7MmTOnVOuWJsEhIipODU0HQERV21tvvYWNGzciKysL+/btw8iRI6Gnp4dp06YVWjc7Oxv6+vqS7NfS0lKSeoiIXoYtS0SkFrlcDjs7Ozg5OeGTTz5Bt27dsGfPHgD/dp3NmzcPDg4OaNiwIQDg3r17eP/992Fubg5LS0u8++67uH37trLOvLw8jB8/Hubm5rCyssLkyZPx4pRwL3bDZWVlYcqUKXB0dIRcLoebmxvWr1+P27dvo2vXrgAACwsLyGQyDBw4EACgUCiwYMECuLi4wNDQEJ6entixY4fKfvbt24cGDRrA0NAQXbt2VYmztKZMmYIGDRrAyMgIrq6umDFjBnJycgqt9+2338LR0RFGRkZ4//33kZycrPL8unXr0LhxYxgYGKBRo0b45ptvyhwLEZUdkyUikpShoSGys7OVj8PDwxEVFYWwsDDs3bsXOTk58PX1hYmJCU6cOIFTp07B2NgYb731lnK7xYsXY9OmTdiwYQNOnjyJxMRE/PLLLyXud8CAAfjhhx+wYsUKXL9+Hd9++y2MjY3h6OiInTt3AgCioqIQFxeH5cuXAwAWLFiALVu2YPXq1fj7778xbtw4fPjhhzh27BiA/KSud+/e6NmzJy5duoShQ4di6tSpZT4mJiYm2LRpE65du4bly5dj7dq1WLp0qco60dHR+Omnn/Dbb79h//79uHjxIj799FPl899//z1mzpyJefPm4fr165g/fz5mzJiBzZs3lzkeIiojQUT0igIDA8W7774rhBBCoVCIsLAwIZfLxcSJE5XP16pVS2RlZSm32bp1q2jYsKFQKBTKsqysLGFoaCgOHDgghBDC3t5eLFq0SPl8Tk6OqFOnjnJfQgjRuXNnMWbMGCGEEFFRUQKACAsLKzLOI0eOCADi2bNnyrLMzExhZGQkTp8+rbLukCFDREBAgBBCiGnTpgl3d3eV56dMmVKorhcBEL/88kuxz3/55ZeiVatWysezZs0Surq64v79+8qyP/74Q+jo6Ii4uDghhBD16tUT27ZtU6lnzpw5ol27dkIIIWJjYwUAcfHixWL3S0SvhmOWiEgte/fuhbGxMXJycqBQKPC///0PwcHByuc9PDxUxilFRkYiOjoaJiYmKvVkZmYiJiYGycnJiIuLQ9u2bZXP1ahRA61bty7UFVfg0qVL0NXVRefOnUsdd3R0NDIyMvDmm2+qlGdnZytvAnz9+nWVOAAobxZcFtu3b8eKFSsQExODtLQ05ObmwtTUVGWdunXronbt2ir7USgUiIqKgomJCWJiYjBkyBAMGzZMuU5ubi7MzMzKHA8RlQ2TJSJSS9euXREaGgp9fX04ODigRg3Vj5WaNWuqPE5LS0OrVq3w/fffF6rLxsbmlWIwNDQs8zZpaWkAgN9//10lSQHyx2FJ5cyZM+jfvz9CQkLg6+sLMzMz/Pjjj1i8eHGZY127dm2h5E1XV1eyWImoaEyWiEgtNWvWhJubW6nXb9myJbZv3w5bW9tCrSsF7O3tERERgU6dOgHIb0H566+/0LJlyyLX9/DwgEKhwLFjx9CtW7dCzxe0bOXl5SnL3N3dIZfLcffu3WJbpBo3bqwcrF7g7NmzL3+R/3H69Gk4OTlh+vTpyrI7d+4UWu/u3bt4+PAhHBwclPvR0dFBw4YNUatWLTg4OODWrVvo379/mfZPROrjAG8iqlD9+/eHtbU13n33XZw4cQKxsbE4evQoRo8ejfv37wMAxowZg4ULF2L37t24ceMGPv300xLnSHJ2dkZgYCAGDx6M3bt3K+v86aefAABOTk6QyWTYu3cv4uPjkZaWBhMTE0ycOBHjxo3D5s2bERMTgwsXLmDlypXKQdMjRozAzZs3MWnSJERFRWHbtm3YtGlTmV5v/fr1cffuXfz444+IiYnBihUrihysbmBggMDAQERGRuLEiRMYPXo03n//fdjZ2QEAQkJCsGDBAqxYsQL//PMPrly5go0bN2LJkiVlioeIyo7JEhFVKCMjIxw/fhx169ZF79690bhxYwwZMgSZmZnKlqYJEybgo48+QmBgINq1awcTExP4+/uXWG9oaCj69u2LTz/9FI0aNcKwYcOQnp4OAKhduzZCQkIwdepU1KpVC0FBQQCAOXPmYMaMGViwYAEaN26Mt956C7///jtcXFwA5I8j2rlzJ3bv3g1PT0+sXr0a8+fPL9PrfeeddzBu3DgEBQWhefPmOH36NGbMmFFoPTc3N/Tu3Rvdu3eHj48PmjVrpjI1wNChQ7Fu3Tps3LgRHh4e6Ny5MzZt2qSMlYjKj0wUN2KSiIiIiNiyRERERFQSJktEREREJWCyRERERFQCJktEREREJWCyRERERFQCJktEREREJWCyRERERFQCJktEREREJWCyRERERFQCJktEREREJWCyRERERFSC/wMLtLMwQrnz7gAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<Figure size 640x480 with 2 Axes>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "cm = skmetrics.confusion_matrix(y_val, y_hat)\n",
+        "disp = skmetrics.ConfusionMatrixDisplay(confusion_matrix=cm,\n",
+        "                              display_labels=labels_dict.keys())\n",
+        "disp.plot(xticks_rotation='vertical')\n",
+        "plt.title('Confusion matrix for newsgroup test dataset');\n",
+        "plt.grid(False)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "iLU1skB9L_67"
+      },
+      "source": [
+        "## Next steps\n",
+        "\n",
+        "You've now created your own text classifier using embeddings generated from the PaLM API! Try using your own textual data to train a model. One possible dataset could be the [Jigsaw Toxic Comment Classification Challenge](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge/data){:.external} to create your own toxicity classifier.\n",
+        "\n",
+        "To learn more about how you can use the embeddings, check out the examples available. To learn how to use other services in the PaLM API, visit the various quickstart guides:\n",
+        "\n",
+        "* [Chat quickstart](../tutorials/chat_quickstart.ipynb)\n",
+        "\n",
+        "* [Text generation quickstart](../tutorials/text_quickstart.ipynb)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "train_text_classifier_embeddings.ipynb",
+      "toc_visible": true,
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/seeds/gems/text_classification/README.md
+++ b/seeds/gems/text_classification/README.md
@@ -1,0 +1,2 @@
+# Text classification with embeddings
+

--- a/seeds/gems/text_classification/README.md
+++ b/seeds/gems/text_classification/README.md
@@ -1,6 +1,5 @@
 # Text classification with embeddings
 
-| Username      | Dataset | Notebook    | Accuracy |
-| :---        |    :----:   |          ---: |
-| [@shilpakancharla](https://github.com/shilpakancharla)     | [20 Newsgroups Text Dataset](https://scikit-learn.org/0.19/datasets/twenty_newsgroups.html)       | [Text classifier](20_newsgroups/train_text_classifier_embeddings.ipynb)  | 92% |
-|    |         |       |    |
+| Username| Dataset | Notebook| Accuracy |
+| :---    | :----:  | :----:  |      ---:|
+|[@shilpakancharla](https://github.com/shilpakancharla)|[20 Newsgroups Text Dataset](https://scikit-learn.org/0.19/datasets/twenty_newsgroups.html)| [Text classifier](20_newsgroups/train_text_classifier_embeddings.ipynb)| 92% |

--- a/seeds/gems/text_classification/README.md
+++ b/seeds/gems/text_classification/README.md
@@ -1,6 +1,6 @@
 # Text classification with embeddings
 
-| Username      | Dataset | Notebook    |
+| Username      | Dataset | Notebook    | Accuracy |
 | :---        |    :----:   |          ---: |
-| [@shilpakancharla](https://github.com/shilpakancharla)     | [20 Newsgroups Text Dataset](https://scikit-learn.org/0.19/datasets/twenty_newsgroups.html)       | [Text classifier](20_newsgroups/train_text_classifier_embeddings.ipynb)  |
-|    |         |       |
+| [@shilpakancharla](https://github.com/shilpakancharla)     | [20 Newsgroups Text Dataset](https://scikit-learn.org/0.19/datasets/twenty_newsgroups.html)       | [Text classifier](20_newsgroups/train_text_classifier_embeddings.ipynb)  | 92% |
+|    |         |       |    |

--- a/seeds/gems/text_classification/README.md
+++ b/seeds/gems/text_classification/README.md
@@ -1,2 +1,0 @@
-# Text classification with embeddings
-

--- a/seeds/gems/text_classification/README.md
+++ b/seeds/gems/text_classification/README.md
@@ -1,4 +1,10 @@
-# Text classification with embeddings
+# 20 Newsgroups Text Dataset
+
+## Dataset description
+
+The [20 Newsgroups Text Dataset](https://scikit-learn.org/0.19/datasets/twenty_newsgroups.html) contains 18,000 newsgroups posts on 20 topics divided into training and test sets. The split between the training and test datasets are based on messages posted before and after a specific date. For this tutorial, you will be using the subsets of the training and test datasets. You will preprocess and organize the data into Pandas dataframes.
+
+## Leaderboard
 
 | Username| Dataset | Notebook| Accuracy |
 | :---    | :----:  | :----:  |      ---:|

--- a/seeds/gems/text_classification/README.md
+++ b/seeds/gems/text_classification/README.md
@@ -1,0 +1,6 @@
+# Text classification with embeddings
+
+| Username      | Dataset | Notebook    |
+| :---        |    :----:   |          ---: |
+| [@shilpakancharla](https://github.com/shilpakancharla)     | [20 Newsgroups Text Dataset](https://scikit-learn.org/0.19/datasets/twenty_newsgroups.html)       | [Text classifier](20_newsgroups/train_text_classifier_embeddings.ipynb)  |
+|    |         |       |


### PR DESCRIPTION
Adding the text classification example into the gems folder. There is a notebook available (let me know how you would prefer it formatted to make it a better public version which is different from the PaLM API docs). 

The leaderboard is simply on the README.md, but we can add more detail and instructions of what users can do going forward.
