### PR TITLE
Safety 1

### DIFF
--- a/graphs.code-workspace
+++ b/graphs.code-workspace
@@ -11,6 +11,9 @@
     },
     {
       "path": "seeds/llm-starter"
+    },
+    {
+      "path": "seeds/graph-safety"
     }
   ],
   "settings": {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -174,6 +174,10 @@
       "resolved": "seeds/graph-runner",
       "link": true
     },
+    "node_modules/@google-labs/graph-safety": {
+      "resolved": "seeds/graph-safety",
+      "link": true
+    },
     "node_modules/@google-labs/llm-starter": {
       "resolved": "seeds/llm-starter",
       "link": true
@@ -3230,6 +3234,19 @@
     },
     "seeds/graph-runner": {
       "name": "@google-labs/graph-runner",
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@ava/typescript": "^4.0.0",
+        "@google-labs/tsconfig": "*",
+        "@types/node": "^18.16.3",
+        "@typescript-eslint/eslint-plugin": "^5.56.0",
+        "@typescript-eslint/parser": "^5.56.0",
+        "ava": "^5.2.0",
+        "typescript": "^5.0.4"
+      }
+    },
+    "seeds/graph-safety": {
       "version": "0.0.1",
       "license": "Apache-2.0",
       "devDependencies": {

--- a/seeds/graph-runner/src/index.ts
+++ b/seeds/graph-runner/src/index.ts
@@ -17,4 +17,5 @@ export type {
   KitDescriptor,
 } from "./types.js";
 export { TraversalMachine } from "./traversal/machine.js";
+export { GraphRepresentation } from "./traversal/representation.js";
 export { toMermaid } from "./mermaid.js";

--- a/seeds/graph-safety/.npmignore
+++ b/seeds/graph-safety/.npmignore
@@ -1,0 +1,2 @@
+.env
+tsconfig.tsbuildinfo

--- a/seeds/graph-safety/README.md
+++ b/seeds/graph-safety/README.md
@@ -1,0 +1,1 @@
+# Your README goes here

--- a/seeds/graph-safety/package.json
+++ b/seeds/graph-safety/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@google-labs/graph-safety",
+  "private": true,
+  "version": "0.0.1",
+  "description": "A library for analyzing the safety of a graph",
+  "main": "./dist/src/index.js",
+  "exports": "./dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "test": "FORCE_COLOR=1 ava",
+    "build": "FORCE_COLOR=1 tsc --b",
+    "watch": "FORCE_COLOR=1 tsc --b --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/google/labs-prototypes"
+  },
+  "files": [
+    "dist/src"
+  ],
+  "ava": {
+    "files": [
+      "tests/**/*.ts"
+    ],
+    "workerThreads": false,
+    "typescript": {
+      "rewritePaths": {
+        "./": "dist/"
+      },
+      "compile": false
+    }
+  },
+  "keywords": [],
+  "author": "Google Labs Team",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/google/labs-prototypes/issues"
+  },
+  "homepage": "https://github.com/google/labs-prototypes#readme",
+  "devDependencies": {
+    "@ava/typescript": "^4.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.56.0",
+    "@typescript-eslint/parser": "^5.56.0",
+    "@types/node": "^18.16.3",
+    "ava": "^5.2.0",
+    "typescript": "^5.0.4",
+    "@google-labs/tsconfig": "*"
+  }
+}

--- a/seeds/graph-safety/src/index.ts
+++ b/seeds/graph-safety/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+console.log("code goes here");

--- a/seeds/graph-safety/src/index.ts
+++ b/seeds/graph-safety/src/index.ts
@@ -4,4 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-console.log("code goes here");
+export { GraphSafetyValidator } from "./validator.js";
+export { SafetyLabel } from "./label.js";
+export type { SafetyLabelValue } from "./types.js";

--- a/seeds/graph-safety/src/label.ts
+++ b/seeds/graph-safety/src/label.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SafetyLabelValue } from './types.js';
+
+/**
+ * Information flow control label.
+ */
+export class SafetyLabel {
+  public readonly value: SafetyLabelValue|undefined;
+
+  /**
+   * @param {SafetyLabelValues|SafetyLabel} value SafetyLabel to copy or SafetyLabelValues to create a new label
+   */
+  constructor(value: SafetyLabel|SafetyLabelValue|undefined = undefined) {
+    this.value = value instanceof SafetyLabel ? value.value : value;
+  }
+
+  /**
+   * Meet is the greatest lower bound of the @property {[SafetyLabel]} labels.
+   * Flow from any of these labels to the meet is allowed.
+   * Use this to compute a label of a node based on its incoming edges.
+   * That is, if a node reads from an UNTRUSTED node, it has to be UNTRUSTED.
+   */
+  static computeMeetOfLabels(labels: (SafetyLabel | undefined)[]): SafetyLabel {
+    const definedLabels = labels.filter((label) => label !== undefined && label.value !== undefined) as SafetyLabel[];
+    if (definedLabels.length === 0) return new SafetyLabel(undefined);
+    return definedLabels.reduce((a, b) => a.value === SafetyLabelValue.TRUSTED && b.value === SafetyLabelValue.TRUSTED
+        ? new SafetyLabel(SafetyLabelValue.TRUSTED)
+        : new SafetyLabel(SafetyLabelValue.UNTRUSTED));
+  }
+
+  /**
+   * Join is the least upper bound of the @property {[SafetyLabel]} labels.
+   * Flow to any of these labels from the join is allowed.
+   * Use this to compute a label of a node based on its outgoing edges.
+   * That is, if a node writes to a TRUSTED node, it has to be TRUSTED.
+   */
+  static computeJoinOfLabels(labels: (SafetyLabel | undefined)[]): SafetyLabel {
+    const definedLabels = labels.filter((label) => label !== undefined && label.value !== undefined) as SafetyLabel[];
+    if (definedLabels.length === 0) return new SafetyLabel(undefined);
+    return definedLabels.reduce((a, b) => a.value === SafetyLabelValue.TRUSTED || b.value === SafetyLabelValue.TRUSTED
+        ? new SafetyLabel(SafetyLabelValue.TRUSTED)
+        : new SafetyLabel(SafetyLabelValue.UNTRUSTED));
+  }
+
+  /**
+   * Compare with other label.
+   * 
+   * @param {SafetyLabel} other label
+   * @returns {Boolean} true if the labels are equal
+   */
+  equalsTo(other: SafetyLabel): boolean {
+    return this.value === other.value;
+  }
+
+  /**
+   * Checks whether the label can flow to the destination label.
+   * 
+   * @param {SafetyLabel} destinationLabel label to flow to
+   * @returns {Boolean} true if the label can flow to the destination label
+   * @throws {Error} if the label or the destination label is undetermined
+   */
+  canFlowTo(destinationLabel: SafetyLabel): boolean {
+    if (this.value === undefined || destinationLabel.value === undefined) throw new Error("Can't decide flow with undetermined label");
+    return this.equalsTo(SafetyLabel.computeJoinOfLabels([this, destinationLabel]));
+  }
+}

--- a/seeds/graph-safety/src/trusted-labels.ts
+++ b/seeds/graph-safety/src/trusted-labels.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { NodeTypeIdentifier } from "@google-labs/graph-runner";
+import { SafetyLabel } from './label.js';
+import { SafetyLabelValue } from './types.js';
+
+/**
+ * Manual assignment of labels to node types.
+ * 
+ * Eventually this should be based on a system of verifiers, etc.
+ * The key for now is that these labels can only be set by a trusted source, which is for now this file.
+ */
+export const trustedLabels: Map<NodeTypeIdentifier, SafetyLabel> = new Map([
+    ["fetch", new SafetyLabel(SafetyLabelValue.UNTRUSTED)],
+    ["run-javascript", new SafetyLabel(SafetyLabelValue.TRUSTED)],
+  ]);

--- a/seeds/graph-safety/src/types.ts
+++ b/seeds/graph-safety/src/types.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Information flow control label values, i.e. levels of trust.
+ * 
+ * This will become more complex over time, but for now, just a simple enum.
+ * Flow is allowed from TRUSTED to TRUSTED, from either to UNTRUSTED, but not from UNTRUSTED to TRUSTED.
+ */
+export enum SafetyLabelValue { UNTRUSTED, TRUSTED }

--- a/seeds/graph-safety/src/validator.ts
+++ b/seeds/graph-safety/src/validator.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphDescriptor, GraphRepresentation, NodeDescriptor } from "@google-labs/graph-runner";
+import { SafetyLabel } from "./label.js";
+import { trustedLabels } from "./trusted-labels.js"
+
+/**
+ * @class GraphSafetyValidator 
+ * 
+ * A validator for the safety of a graph.
+ * Call @method {computeLabelsForFullGraph} to validate the full graph.
+ */
+export class GraphSafetyValidator {
+  protected nodeSafetyLabels: Map<NodeDescriptor['id'], SafetyLabel> = new Map();
+  protected graph: GraphRepresentation;
+
+  constructor(graph: GraphDescriptor) {
+    this.graph = new GraphRepresentation(graph);
+  }
+
+  /**
+   * Compute labels and hence validate the safety of the graph as whole.
+   * @throws {Error} if the graph is not safe.
+   * After this you can use @method {getNodeSafetyLabel} to get the label of any node.
+   * For input nodes, this means the minimum expected trust, and it's up to the callee to ensure that.
+   * A safety label of undefined means that there were no constraints on it either way.
+   * 
+   * Validating the full graph before running it is ideal, but can also be overly strict.
+   * Once we have enough of the tools to create safe graphs, this is the only method that should be used.
+   * 
+   * Until then it might be desirable to instead validate the graph incrementally. TODO: Implement that.
+   */
+  computeLabelsForFullGraph(): void {
+    // This method recomputes all labels from scratch. Initialize with the initial constraints.
+    this.nodeSafetyLabels = new Map();
+
+    // Find all nodes with a constraint label via node types
+    const constraintSafetyLabels: Map<NodeDescriptor['id'], SafetyLabel> = new Map();
+    for (const [nodeId, nodeDescription] of this.graph.nodes) {
+      if (trustedLabels.has(nodeDescription.type)) {
+        constraintSafetyLabels.set(nodeId, trustedLabels.get(nodeDescription.type) as SafetyLabel);
+      }
+    }
+
+    // Compute all labels with an embarrassingly simple and slow fixed-point algorithm.
+    // This should be replaced by a more efficient constraint solver, but that's a lot of work and fiddly.
+    // This should be good enough for now and should even cover some of the next steps.
+    //
+    // Picture raising the trust levels where necessary to enable flow until it stops changing.
+    // That is, this will propagate labels through the graph until it reaches a fixed point.
+    // If it encounters a contradiction with a constraint, it will throw an error, as the graph is not safe.
+    let change: boolean;
+    do {
+      change = false;
+      for (const [nodeId] of this.graph.nodes) {
+        const constraintSafetyLabel = constraintSafetyLabels.get(nodeId);
+
+        const incomingNodes = this.graph.heads.get(nodeId)?.map((edge) => edge.from) || [];
+        const outgoingNodes = this.graph.tails.get(nodeId)?.map((edge) => edge.to) || [];
+
+        // Compute the meet (lowest label) of all incoming edges.
+        // Add the constraint label for this node. This can lower the label, but not raise it.
+        const incomingSafetyLabels = incomingNodes.map((nodeId) => this.nodeSafetyLabels.get(nodeId));
+        const incomingSafetyLabel = SafetyLabel.computeMeetOfLabels([...incomingSafetyLabels, constraintSafetyLabel]);
+
+        // Compute the join (highest label) of all outgoing edges.
+        // Add the constraint label for this node. This can raise the label.
+        const outgoingSafetyLabels = outgoingNodes.map((nodeId) => this.nodeSafetyLabels.get(nodeId));
+        const outgoingSafetyLabel = SafetyLabel.computeJoinOfLabels([...outgoingSafetyLabels, constraintSafetyLabel]);
+
+        // Graph is not safe if a constraint has to be violated, i.e. here a node has to be upgraded.
+        if (constraintSafetyLabel && !outgoingSafetyLabel.equalsTo(constraintSafetyLabel)) {
+          throw Error(`Graph is not safe. E.g. node ${nodeId} requires to write to ${outgoingSafetyLabel} but can only be ${constraintSafetyLabel}`);
+        }
+
+        // Compute the new safety label as the join (highest of) of (lowest) incoming and (highest) outgoing edges.
+        // Note that if this increases the trust of this node, the next iteration will backpropagate that.
+        const newSafetyLabel = SafetyLabel.computeJoinOfLabels([incomingSafetyLabel, outgoingSafetyLabel]);
+        const currentSafetyLabel = this.nodeSafetyLabels.get(nodeId);
+
+        // If the new safety label is different from the current one, update it.
+        if (!currentSafetyLabel || !newSafetyLabel.equalsTo(currentSafetyLabel)) {
+          this.nodeSafetyLabels.set(nodeId, newSafetyLabel);
+          change = true;
+        }
+      }
+    } while (change);
+  }
+
+  /**
+   * Get the safety label of a node.
+   * This is only valid after calling @method {computeLabelsForFullGraph}.
+   * 
+   * @param nodeId The id of the node to get the label for.
+   * @returns The safety label of the node, or undefined if it wasn't computed.
+   *          Note that the safety label's value can be undefined, meaning that there were no constraints on it.
+   */ 
+  getSafetyLabel(nodeId: NodeDescriptor['id']): SafetyLabel {
+    if (!this.nodeSafetyLabels.has(nodeId)) throw Error(`Safety label for node ${nodeId} not computed.`);
+    return this.nodeSafetyLabels.get(nodeId) as SafetyLabel;
+  }
+}

--- a/seeds/graph-safety/tests/data/fetch-after-javascript-safe.json
+++ b/seeds/graph-safety/tests/data/fetch-after-javascript-safe.json
@@ -27,10 +27,10 @@
   ],
   "safe": true,
   "expectedLabels": [
-    ["input-1", 1],
-    ["javascript-1", 1],
-    ["fetch-1", 0],
-    ["output-1", 0]
+    ["input-1", "TRUSTED"],
+    ["javascript-1", "TRUSTED"],
+    ["fetch-1", "UNTRUSTED"],
+    ["output-1", "UNTRUSTED"]
   ],
   "explanation": "Fetch output is untrusted, but only goes to output. Javascript requires trusted input, so input nodes needs to be trusted."
 }

--- a/seeds/graph-safety/tests/data/fetch-after-javascript-safe.json
+++ b/seeds/graph-safety/tests/data/fetch-after-javascript-safe.json
@@ -1,0 +1,36 @@
+{
+  "edges": [
+    {
+      "from": "input-1",
+      "out": "text",
+      "to": "javascript-1",
+      "in": "compute"
+    },
+    {
+      "from": "javascript-1",
+      "out": "result",
+      "to": "fetch-1",
+      "in": "url"
+    },
+    {
+      "from": "fetch-1",
+      "out": "response",
+      "to": "output-1",
+      "in": "text"
+    }
+  ],
+  "nodes": [
+    { "id": "input-1", "type": "input" },
+    { "id": "fetch-1", "type": "fetch" },
+    { "id": "javascript-1", "type": "run-javascript", "configuration": { "name": "compute" } },
+    { "id": "output-1", "type": "output" }
+  ],
+  "safe": true,
+  "expectedLabels": [
+    ["input-1", 1],
+    ["javascript-1", 1],
+    ["fetch-1", 0],
+    ["output-1", 0]
+  ],
+  "explanation": "Fetch output is untrusted, but only goes to output. Javascript requires trusted input, so input nodes needs to be trusted."
+}

--- a/seeds/graph-safety/tests/data/javascript-after-fetch-not-allowed.json
+++ b/seeds/graph-safety/tests/data/javascript-after-fetch-not-allowed.json
@@ -1,0 +1,30 @@
+{
+  "edges": [
+    {
+      "from": "input-1",
+      "out": "text",
+      "to": "fetch-1",
+      "in": "url"
+    },
+    {
+      "from": "fetch-1",
+      "out": "response",
+      "to": "javascript-1",
+      "in": "compute"
+    },
+    {
+      "from": "javascript-1",
+      "out": "result",
+      "to": "output-1",
+      "in": "text"
+    }
+  ],
+  "nodes": [
+    { "id": "input-1", "type": "input" },
+    { "id": "fetch-1", "type": "fetch" },
+    { "id": "javascript-1", "type": "run-javascript", "configuration": { "name": "compute" } },
+    { "id": "output-1", "type": "output" }
+  ],
+  "safe": false,
+  "explanation": "Fetch output is untrusted, Javascript requires trusted input, so this is unsafe."
+}

--- a/seeds/graph-safety/tests/data/loop-with-fetch-and-javascript-in-parallel-not-safe.json
+++ b/seeds/graph-safety/tests/data/loop-with-fetch-and-javascript-in-parallel-not-safe.json
@@ -1,0 +1,56 @@
+{
+  "edges": [
+    {
+      "from": "input-1",
+      "out": "text",
+      "to": "do-1",
+      "in": "task"
+    },
+    {
+      "from": "do-1",
+      "out": "execute",
+      "to": "javascript-1",
+      "in": "compute"
+    },
+    {
+      "from": "javascript-1",
+      "out": "result",
+      "to": "while-1",
+      "in": "result"
+    },
+    {
+      "from": "do-1",
+      "out": "fetch",
+      "to": "fetch-1",
+      "in": "url"
+    },
+    {
+      "from": "fetch-1",
+      "out": "response",
+      "to": "while-1",
+      "in": "result"
+    },
+    {
+      "from": "while-1",
+      "out": "observation",
+      "to": "do-1",
+      "in": "observation"
+    },
+    {
+      "from": "while-1",
+      "out": "result",
+      "to": "output-1",
+      "in": "text"
+    }
+  ],
+  "nodes": [
+    { "id": "input-1", "type": "input" },
+    { "id": "do-1", "type": "do" },
+    { "id": "while-1", "type": "while" },
+    { "id": "fetch-1", "type": "fetch" },
+    { "id": "javascript-1", "type": "run-javascript", "configuration": { "name": "compute" } },
+    { "id": "output-1", "type": "output" }
+  ],
+  "safe": false,
+  "explanation": "This is a subset of ReAct, and it is not safe, because javascript can be called with fetch's output, which is untrusted."
+}

--- a/seeds/graph-safety/tests/data/simple-trusted.json
+++ b/seeds/graph-safety/tests/data/simple-trusted.json
@@ -20,8 +20,8 @@
   ],
   "safe": true,
   "expectedLabels": [
-    ["javascript-1", 1],
-    ["output-1", 1]
+    ["javascript-1", "TRUSTED"],
+    ["output-1", "TRUSTED"]
   ],
   "explanation": "Javascript requires trusted inputs -> input has to be trusted"
 }

--- a/seeds/graph-safety/tests/data/simple-trusted.json
+++ b/seeds/graph-safety/tests/data/simple-trusted.json
@@ -1,0 +1,27 @@
+{
+  "edges": [
+    {
+      "from": "input-1",
+      "out": "text",
+      "to": "javascript-1",
+      "in": "compute"
+    },
+    {
+      "from": "javascript-1",
+      "out": "result",
+      "to": "output-1",
+      "in": "text"
+    }
+  ],
+  "nodes": [
+    { "id": "input-1", "type": "input" },
+    { "id": "javascript-1", "type": "run-javascript", "configuration": { "name": "compute" } },
+    { "id": "output-1", "type": "output" }
+  ],
+  "safe": true,
+  "expectedLabels": [
+    ["javascript-1", 1],
+    ["output-1", 1]
+  ],
+  "explanation": "Javascript requires trusted inputs -> input has to be trusted"
+}

--- a/seeds/graph-safety/tests/data/simple-untrusted.json
+++ b/seeds/graph-safety/tests/data/simple-untrusted.json
@@ -1,0 +1,27 @@
+{
+  "edges": [
+    {
+      "from": "input-1",
+      "out": "text",
+      "to": "fetch-1",
+      "in": "url"
+    },
+    {
+      "from": "fetch-1",
+      "out": "response",
+      "to": "output-1",
+      "in": "text"
+    }
+  ],
+  "nodes": [
+    { "id": "input-1", "type": "input" },
+    { "id": "fetch-1", "type": "fetch" },
+    { "id": "output-1", "type": "output" }
+  ],
+  "safe": true,
+  "expectedLabels": [
+    ["fetch-1", 0],
+    ["output-1", 0]
+  ],
+  "explanation": "Fetch output is untrusted -> output has to be untrusted"
+}

--- a/seeds/graph-safety/tests/data/simple-untrusted.json
+++ b/seeds/graph-safety/tests/data/simple-untrusted.json
@@ -20,8 +20,8 @@
   ],
   "safe": true,
   "expectedLabels": [
-    ["fetch-1", 0],
-    ["output-1", 0]
+    ["fetch-1", "UNTRUSTED"],
+    ["output-1", "UNTRUSTED"]
   ],
   "explanation": "Fetch output is untrusted -> output has to be untrusted"
 }

--- a/seeds/graph-safety/tests/data/simple.json
+++ b/seeds/graph-safety/tests/data/simple.json
@@ -13,8 +13,8 @@
   ],
   "safe": true,
   "expectedLabels": [
-    ["input-1"],
-    ["output-1"]
+    ["input-1", "UNDEFINED"],
+    ["output-1", "UNDEFINED"]
   ],
   "explanation": "No constraints -> undefined labels"
 }

--- a/seeds/graph-safety/tests/data/simple.json
+++ b/seeds/graph-safety/tests/data/simple.json
@@ -1,0 +1,20 @@
+{
+  "edges": [
+    {
+      "from": "input-1",
+      "out": "text",
+      "to": "output-1",
+      "in": "text"
+    }
+  ],
+  "nodes": [
+    { "id": "input-1", "type": "input" },
+    { "id": "output-1", "type": "output" }
+  ],
+  "safe": true,
+  "expectedLabels": [
+    ["input-1"],
+    ["output-1"]
+  ],
+  "explanation": "No constraints -> undefined labels"
+}

--- a/seeds/graph-safety/tests/label.ts
+++ b/seeds/graph-safety/tests/label.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test from "ava";
+
+import { SafetyLabel } from "../src/label.js";
+import { SafetyLabelValue } from "../src/types.js";
+
+test("SafetyLabel: constructor", (t) => {
+  const trusted = new SafetyLabel(SafetyLabelValue.TRUSTED);
+  t.is(trusted.value, SafetyLabelValue.TRUSTED);
+
+  const untrusted = new SafetyLabel(SafetyLabelValue.UNTRUSTED);
+  t.is(untrusted.value, SafetyLabelValue.UNTRUSTED);
+
+  const undetermined = new SafetyLabel(undefined);
+  t.is(undetermined.value, undefined);
+
+  const trustedCopy = new SafetyLabel(trusted);
+  t.is(trustedCopy.value, SafetyLabelValue.TRUSTED);
+
+  const untrustedCopy = new SafetyLabel(untrusted);
+  t.is(untrustedCopy.value, SafetyLabelValue.UNTRUSTED);
+
+  const undeterminedCopy = new SafetyLabel(undetermined);
+  t.is(undeterminedCopy.value, undefined);
+});
+
+test("SafetyLabel: equalsTo", (t) => {
+  const trusted = new SafetyLabel(SafetyLabelValue.TRUSTED);
+  const untrusted = new SafetyLabel(SafetyLabelValue.UNTRUSTED);
+  const undetermined = new SafetyLabel(undefined);
+
+  t.true(trusted.equalsTo(trusted));
+  t.true(untrusted.equalsTo(untrusted));
+  t.true(undetermined.equalsTo(undetermined));
+
+  t.false(trusted.equalsTo(untrusted));
+  t.false(trusted.equalsTo(undetermined));
+  t.false(untrusted.equalsTo(trusted));
+  t.false(untrusted.equalsTo(undetermined));
+  t.false(undetermined.equalsTo(trusted));
+  t.false(undetermined.equalsTo(untrusted));
+});
+
+test("SafetyLabel: meet and join", (t) => {
+  const trusted = new SafetyLabel(SafetyLabelValue.TRUSTED);
+  const untrusted = new SafetyLabel(SafetyLabelValue.UNTRUSTED);
+  const undetermined = new SafetyLabel(undefined);
+
+  t.true(SafetyLabel.computeMeetOfLabels([trusted]).equalsTo(trusted));
+  t.true(SafetyLabel.computeMeetOfLabels([trusted, trusted]).equalsTo(trusted));
+  t.true(SafetyLabel.computeMeetOfLabels([untrusted, untrusted]).equalsTo(untrusted));
+  t.true(SafetyLabel.computeMeetOfLabels([trusted, untrusted]).equalsTo(untrusted));
+
+  t.true(SafetyLabel.computeMeetOfLabels([undetermined]).equalsTo(undetermined));
+  t.true(SafetyLabel.computeMeetOfLabels([undetermined, trusted]).equalsTo(trusted));
+  t.true(SafetyLabel.computeMeetOfLabels([undetermined, trusted, trusted]).equalsTo(trusted));
+  t.true(SafetyLabel.computeMeetOfLabels([undetermined, untrusted, untrusted]).equalsTo(untrusted));
+  t.true(SafetyLabel.computeMeetOfLabels([undetermined, trusted, untrusted]).equalsTo(untrusted));
+
+  t.true(SafetyLabel.computeMeetOfLabels([]).equalsTo(undetermined));
+  t.true(SafetyLabel.computeMeetOfLabels([undefined]).equalsTo(undetermined));
+  t.true(SafetyLabel.computeMeetOfLabels([undetermined, undefined]).equalsTo(undetermined));
+  t.true(SafetyLabel.computeMeetOfLabels([undetermined, undefined, trusted]).equalsTo(trusted));
+  t.true(SafetyLabel.computeMeetOfLabels([undetermined, undefined, trusted, trusted]).equalsTo(trusted));
+  t.true(SafetyLabel.computeMeetOfLabels([undetermined, undefined, untrusted, untrusted]).equalsTo(untrusted));
+  t.true(SafetyLabel.computeMeetOfLabels([undetermined, undefined, trusted, untrusted]).equalsTo(untrusted));
+
+  t.true(SafetyLabel.computeJoinOfLabels([trusted]).equalsTo(trusted));
+  t.true(SafetyLabel.computeJoinOfLabels([trusted, trusted]).equalsTo(trusted));
+  t.true(SafetyLabel.computeJoinOfLabels([untrusted, untrusted]).equalsTo(untrusted));
+  t.true(SafetyLabel.computeJoinOfLabels([trusted, untrusted]).equalsTo(trusted));
+
+  t.true(SafetyLabel.computeJoinOfLabels([undetermined]).equalsTo(undetermined));
+  t.true(SafetyLabel.computeJoinOfLabels([undetermined, trusted]).equalsTo(trusted));
+  t.true(SafetyLabel.computeJoinOfLabels([undetermined, trusted, trusted]).equalsTo(trusted));
+  t.true(SafetyLabel.computeJoinOfLabels([undetermined, untrusted, untrusted]).equalsTo(untrusted));
+  t.true(SafetyLabel.computeJoinOfLabels([undetermined, trusted, untrusted]).equalsTo(trusted));
+
+  t.true(SafetyLabel.computeJoinOfLabels([]).equalsTo(undetermined));
+  t.true(SafetyLabel.computeJoinOfLabels([undefined]).equalsTo(undetermined));
+  t.true(SafetyLabel.computeJoinOfLabels([undetermined, undefined]).equalsTo(undetermined));
+  t.true(SafetyLabel.computeJoinOfLabels([undetermined, undefined, trusted]).equalsTo(trusted));
+  t.true(SafetyLabel.computeJoinOfLabels([undetermined, undefined, trusted, trusted]).equalsTo(trusted));
+  t.true(SafetyLabel.computeJoinOfLabels([undetermined, undefined, untrusted, untrusted]).equalsTo(untrusted));
+  t.true(SafetyLabel.computeJoinOfLabels([undetermined, undefined, trusted, untrusted]).equalsTo(trusted));
+});
+
+test("SafetyLabel: canFlowTo", (t) => {
+  const trusted = new SafetyLabel(SafetyLabelValue.TRUSTED);
+  const untrusted = new SafetyLabel(SafetyLabelValue.UNTRUSTED);
+  const undetermined = new SafetyLabel(undefined);
+
+  t.true(trusted.canFlowTo(trusted));
+  t.true(trusted.canFlowTo(untrusted));
+  t.throws(() => trusted.canFlowTo(undetermined));
+
+  t.true(untrusted.canFlowTo(untrusted));
+  t.throws(() => untrusted.canFlowTo(undetermined));
+  t.false(untrusted.canFlowTo(trusted));
+
+  t.throws(() => undetermined.canFlowTo(undetermined));
+  t.throws(() => undetermined.canFlowTo(trusted));
+  t.throws(() => undetermined.canFlowTo(untrusted));
+});
+

--- a/seeds/graph-safety/tests/validator.ts
+++ b/seeds/graph-safety/tests/validator.ts
@@ -17,9 +17,13 @@ const IN_DIR = "./tests/data/";
 
 // Copied and modified from graph-runner/tests/machines.ts
 
+// In the JSON file, for now note expected labels like this:
+// ["node-id", 1] for TRUSTED
+// ["node-id", 0] for UNTRUSTED
+// ["node-id"] for undefined (not the omission of the second element)
 interface TestGraphDescriptor extends GraphDescriptor {
   safe: boolean;
-  expectedLabels: Array<[NodeDescriptor['id'], SafetyLabelValue]>;
+  expectedLabels?: Array<[NodeDescriptor['id'], SafetyLabelValue]>;
 }
 
 const graphs = (await readdir(`${IN_DIR}/`)).filter((file) =>
@@ -36,7 +40,7 @@ await Promise.all(
 
       if (graph.safe) {
         validator.computeLabelsForFullGraph();
-        for (const [nodeId, expectedLabel] of graph.expectedLabels) {
+        for (const [nodeId, expectedLabel] of graph.expectedLabels || []) {
           const derivedLabel = validator.getSafetyLabel(nodeId);
           t.true(derivedLabel.equalsTo(new SafetyLabel(expectedLabel)));
         }

--- a/seeds/graph-safety/tests/validator.ts
+++ b/seeds/graph-safety/tests/validator.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test from "ava";
+
+import { readFile, readdir } from "fs/promises";
+
+import { GraphDescriptor, NodeDescriptor } from "@google-labs/graph-runner";
+import { GraphSafetyValidator } from "../src/validator.js";
+import { SafetyLabel } from "../src/label.js";
+import { SafetyLabelValue } from "../src/types.js";
+
+const IN_DIR = "./tests/data/";
+
+// Copied and modified from graph-runner/tests/machines.ts
+
+interface TestGraphDescriptor extends GraphDescriptor {
+  safe: boolean;
+  expectedLabels: Array<[NodeDescriptor['id'], SafetyLabelValue]>;
+}
+
+const graphs = (await readdir(`${IN_DIR}/`)).filter((file) =>
+  file.endsWith(".json")
+);
+
+await Promise.all(
+  graphs.map(async (filename) => {
+    test(filename, async (t) => {
+      const data = await readFile(`${IN_DIR}${filename}`, "utf-8");
+      const graph = JSON.parse(data) as TestGraphDescriptor;
+
+      const validator = new GraphSafetyValidator(graph);
+
+      if (graph.safe) {
+        validator.computeLabelsForFullGraph();
+        for (const [nodeId, expectedLabel] of graph.expectedLabels) {
+          const derivedLabel = validator.getSafetyLabel(nodeId);
+          t.true(derivedLabel.equalsTo(new SafetyLabel(expectedLabel)));
+        }
+      } else {
+        t.throws(() => validator.computeLabelsForFullGraph());
+      }
+    });
+  })
+);
+
+test("GraphSafetyValidator: no labels before computation", (t) => {
+  const v = new GraphSafetyValidator({
+    edges: [],
+    nodes: [
+      { id: "a", type: "input" }
+    ]
+  });
+
+  t.throws(() => v.getSafetyLabel("a"));
+});

--- a/seeds/graph-safety/tests/validator.ts
+++ b/seeds/graph-safety/tests/validator.ts
@@ -12,7 +12,6 @@ import { GraphDescriptor, NodeDescriptor } from "@google-labs/graph-runner";
 import { GraphSafetyValidator } from "../src/validator.js";
 import { SafetyLabel } from "../src/label.js";
 import { SafetyLabelValue } from "../src/types.js";
-import { isUndefined } from "util";
 
 const IN_DIR = "./tests/data/";
 

--- a/seeds/graph-safety/tsconfig.json
+++ b/seeds/graph-safety/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "extends": "@google-labs/tsconfig/base.json"
+}


### PR DESCRIPTION
Starts work on #46

Initial PR for adding safety enforcement in graphs:
- set up `graph-safety` package
- add very simple `SafetyLabel`, but will all the math-y bits exposed already
- add simple `GraphSafetyValidator` that computes information flow labels for a graph and verifies that the graph is safe, according to them
- export `GraphRepresentation` from `graph-runner` that `GraphSafetyValidator` uses to traverse the graph
- add stub trusted node types list, which should later be replaced by proper declarations
- add tests for the above and test graphs that demonstrate the interplay between fetch and run-javascript is working correctly