### PR TITLE
Make breadbord tutorial import paths file-relative

### DIFF
--- a/seeds/breadboard/docs/tutorial/tutorial-4.js
+++ b/seeds/breadboard/docs/tutorial/tutorial-4.js
@@ -8,6 +8,10 @@ import { Board } from "@google-labs/breadboard";
 import { Starter } from "@google-labs/llm-starter";
 import { config } from "dotenv";
 
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+const __dir = path.dirname(fileURLToPath(import.meta.url));
+
 config();
 
 const board = new Board();
@@ -30,9 +34,9 @@ const json = JSON.stringify(board, null, 2);
 
 import { writeFile } from "fs/promises";
 
-await writeFile("./docs/tutorial/tutorial-4.json", json);
+await writeFile(path.join(__dir, "tutorial-4.json"), json);
 
-const board2 = await Board.load("./docs/tutorial/tutorial-4.json");
+const board2 = await Board.load(path.join(__dir, "tutorial-4.json"));
 
 const result = await board2.runOnce({
   say: "Hi, how are you?",

--- a/seeds/breadboard/docs/tutorial/tutorial-6a.js
+++ b/seeds/breadboard/docs/tutorial/tutorial-6a.js
@@ -10,6 +10,10 @@ import { writeFile } from "fs/promises";
 
 import { config } from "dotenv";
 
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+const __dir = path.dirname(fileURLToPath(import.meta.url));
+
 config();
 
 const board = new Board();
@@ -37,4 +41,4 @@ input.wire(
 );
 
 const json = JSON.stringify(board, null, 2);
-await writeFile("./docs/tutorial/news-summarizer.json", json);
+await writeFile(path.join(__dir, "news-summarizer.json"), json);


### PR DESCRIPTION
A couple of the tutorial examples failed for me because it assumed I was in the `seeds/breadboard` folder when I was actually in `seeds/breadboard/docs/tutorial`. This change will make the read/write paths work from any directory, and should also make them work on Windows by not assuming the `/` delimiter.

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
