### PR TITLE
Ensure llm-starter nodes export a NodeHandler

### DIFF
--- a/seeds/llm-starter/src/nodes/append.ts
+++ b/seeds/llm-starter/src/nodes/append.ts
@@ -7,6 +7,7 @@
 import {
   InputValues,
   NodeDescriberFunction,
+  NodeHandler,
   NodeValue,
   OutputValues,
   Schema,
@@ -117,4 +118,4 @@ export default {
         };
     }
   },
-};
+} satisfies NodeHandler;

--- a/seeds/llm-starter/src/nodes/embed-text.ts
+++ b/seeds/llm-starter/src/nodes/embed-text.ts
@@ -9,6 +9,7 @@ import {
   type InputValues,
   type NodeValue,
   type OutputValues,
+  NodeHandler,
 } from "@google-labs/breadboard";
 import { EmbedTextResponse, palm } from "@google-labs/palm-lite";
 
@@ -61,7 +62,7 @@ export const embedTextDescriber: NodeDescriberFunction = async () => {
 };
 
 export default {
-  descirbe: embedTextDescriber,
+  describe: embedTextDescriber,
   invoke: async (inputs: InputValues): Promise<OutputValues> => {
     const values = inputs as EmbedTextInputs;
     if (!values.PALM_KEY)
@@ -88,4 +89,4 @@ export default {
 
     return { embedding } as OutputValues;
   },
-};
+} satisfies NodeHandler;

--- a/seeds/llm-starter/src/nodes/fetch.ts
+++ b/seeds/llm-starter/src/nodes/fetch.ts
@@ -7,6 +7,7 @@
 import type {
   InputValues,
   NodeDescriberFunction,
+  NodeHandler,
 } from "@google-labs/breadboard";
 
 export type FetchOutputs = {
@@ -108,4 +109,4 @@ export default {
     const response = raw ? await data.text() : await data.json();
     return { response };
   },
-};
+} satisfies NodeHandler;

--- a/seeds/llm-starter/src/nodes/generate-text.ts
+++ b/seeds/llm-starter/src/nodes/generate-text.ts
@@ -10,6 +10,7 @@ import type {
   OutputValues,
   ErrorCapability,
   NodeDescriberFunction,
+  NodeHandler,
 } from "@google-labs/breadboard";
 import {
   GenerateTextResponse,
@@ -143,4 +144,4 @@ export default {
   invoke: async (inputs: InputValues) => {
     return await prepareResponse(await fetch(prepareRequest(inputs)));
   },
-};
+} satisfies NodeHandler;

--- a/seeds/llm-starter/src/nodes/jsonata.ts
+++ b/seeds/llm-starter/src/nodes/jsonata.ts
@@ -10,6 +10,7 @@ import {
   NodeHandlerFunction,
   NodeHandlerContext,
   Schema,
+  NodeHandler,
 } from "@google-labs/breadboard";
 
 import jsonata from "jsonata";
@@ -110,4 +111,4 @@ export const jsonataDescriber: NodeDescriberFunction = async (
 export default {
   describe: jsonataDescriber,
   invoke: jsonataHandler,
-};
+} satisfies NodeHandler;

--- a/seeds/llm-starter/src/nodes/prompt-template.ts
+++ b/seeds/llm-starter/src/nodes/prompt-template.ts
@@ -7,6 +7,7 @@
 import type {
   InputValues,
   NodeDescriberFunction,
+  NodeHandler,
   NodeHandlerFunction,
   Schema,
 } from "@google-labs/breadboard";
@@ -60,7 +61,7 @@ export const promptTemplateHandler: NodeHandlerFunction = async (
 };
 
 export const computeInputSchema = (inputs: InputValues): Schema => {
-  const parameters = parametersFromTemplate(inputs.template as string);
+  const parameters = parametersFromTemplate((inputs.template ?? '') as string);
   const properties: Schema["properties"] = parameters.reduce(
     (acc, parameter) => {
       const schema = {
@@ -107,4 +108,4 @@ export const promptTemplateDescriber: NodeDescriberFunction = async (
 export default {
   describe: promptTemplateDescriber,
   invoke: promptTemplateHandler,
-};
+} satisfies NodeHandler;

--- a/seeds/llm-starter/src/nodes/run-javascript.ts
+++ b/seeds/llm-starter/src/nodes/run-javascript.ts
@@ -7,6 +7,7 @@
 import type {
   InputValues,
   NodeDescriberFunction,
+  NodeHandler,
   NodeHandlerFunction,
   Schema,
 } from "@google-labs/breadboard";
@@ -158,4 +159,4 @@ export const runJavascriptDescriber: NodeDescriberFunction = async (
 export default {
   describe: runJavascriptDescriber,
   invoke: runJavascriptHandler,
-};
+} satisfies NodeHandler;

--- a/seeds/llm-starter/src/nodes/secrets.ts
+++ b/seeds/llm-starter/src/nodes/secrets.ts
@@ -12,6 +12,7 @@
 import type {
   InputValues,
   NodeDescriberFunction,
+  NodeHandler,
   OutputValues,
 } from "@google-labs/breadboard";
 
@@ -111,4 +112,4 @@ export default {
       )
     ) as OutputValues;
   },
-};
+} satisfies NodeHandler;

--- a/seeds/llm-starter/src/nodes/url-template.ts
+++ b/seeds/llm-starter/src/nodes/url-template.ts
@@ -7,6 +7,7 @@
 import type {
   InputValues,
   NodeDescriberFunction,
+  NodeHandler,
   NodeHandlerFunction,
   Schema,
 } from "@google-labs/breadboard";
@@ -123,4 +124,4 @@ export const urlTemplateDescriber: NodeDescriberFunction = async (
 export default {
   describe: urlTemplateDescriber,
   invoke: urlTemplateHandler,
-};
+} satisfies NodeHandler;

--- a/seeds/llm-starter/src/nodes/xml-to-json.ts
+++ b/seeds/llm-starter/src/nodes/xml-to-json.ts
@@ -6,6 +6,7 @@
 
 import type {
   InputValues,
+  NodeHandler,
   NodeValue,
   OutputValues,
 } from "@google-labs/breadboard";
@@ -95,4 +96,4 @@ export default {
     const json = toAltJson(parseXml(xml));
     return { json };
   },
-};
+} satisfies NodeHandler;


### PR DESCRIPTION
Fix a typo in `embed-text.ts` and make node handler exports satisfy `NodeHandler`. 

Also, allow passing an empty input to prompt-template's describe function.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- N/A: Appropriate changes to documentation are included in the PR
