### PR TITLE
Do not add the request body if fetch is using 'GET'

### DIFF
--- a/seeds/llm-starter/src/nodes/fetch.ts
+++ b/seeds/llm-starter/src/nodes/fetch.ts
@@ -100,11 +100,14 @@ export default {
       raw,
     } = inputs as FetchInputs;
     if (!url) throw new Error("Fetch requires `url` input");
-    const init = {
+    const init: RequestInit = {
       method,
       headers,
-      body: JSON.stringify(body),
     };
+    // GET can not have a body.
+    if (method !== "GET") {
+      init.body = JSON.stringify(body);
+    }
     const data = await fetch(url, init);
     const response = raw ? await data.text() : await data.json();
     return { response };


### PR DESCRIPTION
Fixes #N/A

The fetch node in llm-starter was able to call `fetch` using the GET method and pass a body to it. This isn't allowed by the `fetch` api. Prevent this from happening by only adding the body to the request if the method is not GET.


- [x] Tests pass
- N/A? Appropriate changes to documentation are included in the PR
