### PR TITLE
Set 'text' and 'PALM_KEY' as required in generateText

### DIFF
--- a/seeds/llm-starter/src/nodes/generate-text.ts
+++ b/seeds/llm-starter/src/nodes/generate-text.ts
@@ -119,6 +119,7 @@ export const generateTextDescriber: NodeDescriberFunction = async () => {
           },
         },
       },
+      required: ["text", "PALM_KEY"],
     },
     outputSchema: {
       type: "object",


### PR DESCRIPTION
This marks stopSequences and safetySettings as optional.

Fixes N/A

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- N/A Appropriate changes to documentation are included in the PR
