### PR TITLE
Add support for saving board diagrams and manifest entries in nested directories

### DIFF
--- a/seeds/create-breadboard/assets/src/make-graphs.ts
+++ b/seeds/create-breadboard/assets/src/make-graphs.ts
@@ -5,7 +5,7 @@
  */
 
 import { toMermaid } from "@google-labs/breadboard";
-import { mkdir, readdir, writeFile } from "fs/promises";
+import { mkdir, readdir, writeFile, stat } from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -18,26 +18,57 @@ const DIAGRAM_PATH = path.join(MODULE_DIR, "../docs/graphs");
 await mkdir(GRAPH_PATH, { recursive: true });
 await mkdir(DIAGRAM_PATH, { recursive: true });
 
-const saveAllBoards = async () => {
-  const files = await readdir(PATH);
-  const manifest = [];
-  for (const file of files) {
-    if (file.endsWith(".ts")) {
-      const board = await import(path.join(PATH, file));
-      const jsonFile = file.replace(".ts", ".json");
-      manifest.push({
-        title: board.default.title,
-        url: `/graphs/${jsonFile}`,
-      });
-      await writeFile(
-        path.join(GRAPH_PATH, jsonFile),
-        JSON.stringify(board.default, null, 2)
-      );
-      await writeFile(
-        path.join(DIAGRAM_PATH, file.replace(".ts", ".md")),
-        `## ${file}\n\n\`\`\`mermaid\n${toMermaid(board.default)}\n\`\`\``
-      );
+const findTsFiles = async (dir: string | Buffer | URL): Promise<string[]> => {
+  let files = await readdir(dir, { withFileTypes: true });
+  let tsFiles: string[] = [];
+  for (let file of files) {
+    const res = path.resolve(<string>dir, file.name);
+    if (file.isDirectory()) {
+      tsFiles = tsFiles.concat(await findTsFiles(res));
+    } else if (file.isFile() && file.name.endsWith('.ts')) {
+      tsFiles.push(res);
     }
+  }
+  return tsFiles;
+};
+
+const saveBoard = async (filePath: string) => {
+  const board = await import(filePath);
+  const relativePath = path.relative(PATH, filePath);
+  const baseName = path.basename(filePath);
+  const jsonFile = baseName.replace(".ts", ".json");
+  const diagramFile = baseName.replace(".ts", ".md");
+
+  // Create corresponding directories based on the relative path
+  const graphDir = path.dirname(path.join(GRAPH_PATH, relativePath));
+  const diagramDir = path.dirname(path.join(DIAGRAM_PATH, relativePath));
+
+  // Make sure the directories exist
+  await mkdir(graphDir, { recursive: true });
+  await mkdir(diagramDir, { recursive: true });
+
+  const manifestEntry = {
+    title: board.default.title,
+    url: `/graphs/${relativePath.replace('.ts', '.json')}`,
+  };
+
+  await writeFile(
+    path.join(graphDir, jsonFile),
+    JSON.stringify(board.default, null, 2)
+  );
+  await writeFile(
+    path.join(diagramDir, diagramFile),
+    `## ${baseName}\n\n\`\`\`mermaid\n${toMermaid(board.default)}\n\`\`\``
+  );
+  return manifestEntry;
+};
+
+const saveAllBoards = async () => {
+  const tsFiles = await findTsFiles(PATH);
+  const manifest = [];
+  for (const file of tsFiles) {
+    const manifestEntry = await saveBoard(file);
+    manifest.push(manifestEntry);
   }
   await writeFile(
     path.join(MANIFEST_PATH, "local-boards.json"),


### PR DESCRIPTION
This commit adds support for saving board diagrams and manifest entries. It introduces the `findTsFiles` function to recursively find TypeScript files in a directory, and the `saveBoard` function to save a board's JSON file and diagram file. The existing `saveAllBoards` function is updated to use these new functions. Now, all boards in the specified directory will be saved as JSON files and corresponding diagram files, along with their manifest entries in the local-boards.json file.
