### PR TITLE
Allow user to configure which html tags to exclude.

### DIFF
--- a/seeds/chunker-python/README.md
+++ b/seeds/chunker-python/README.md
@@ -33,6 +33,9 @@ aggregated into passages under `max_words_per_aggregate_passage` words. If
 cannot be combined into a single passage under
 `max_words_per_aggregate_passage` words.
 
+`html_tags_to_exclude`: Text within any of the tags in this set will not be
+included in the output passages. Defaults to `{"noscript", "script", "style"}`.
+
 If you find your passages are too disjointed (insufficient context in a single
 passage for your application), consider increasing
 `max_words_per_aggregate_passage` and/or setting
@@ -125,3 +128,19 @@ The sibling children of the `<p>` node are greedily aggregated while the total
 is <=4 words:
 
 passages: ["Heading", "Text before link", "and after."]
+
+
+### Example 5
+
+```
+chunker = HtmlChunker(
+    max_words_per_aggregate_passage=4,
+    greedily_aggregate_sibling_nodes=False,
+    html_tags_to_exclude={"p"}
+)
+passages = chunker.chunk(html)
+```
+
+All text within the `<p>` tag is excluded from the output.:
+
+passages: ["Heading"]

--- a/seeds/chunker-python/pyproject.toml
+++ b/seeds/chunker-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google_labs_html_chunker"
-version = "0.0.3"
+version = "0.0.5"
 authors = [
   { name="Google Labs", email="labs-pypi@google.com" },
 ]

--- a/seeds/chunker-python/src/main.py
+++ b/seeds/chunker-python/src/main.py
@@ -25,6 +25,7 @@ if __name__ == "__main__":
   arg_parser.add_argument("-o", "--outfile", help="Output passages file path.", required=True)
   arg_parser.add_argument("--maxwords", type=int, default=200, help="Max words per aggregate passage.")
   arg_parser.add_argument("--greedyagg", action=argparse.BooleanOptionalAction, help="Whether to greedily aggregate sibling nodes.")
+  arg_parser.add_argument("--excludetags", type=str, default="noscript,script,style", help="Comma-separated HTML tags from which to exclude text.")
   args = arg_parser.parse_args()
 
   html_file = open(args.infile, "r")
@@ -34,6 +35,7 @@ if __name__ == "__main__":
   chunker = HtmlChunker(
       max_words_per_aggregate_passage=args.maxwords,
       greedily_aggregate_sibling_nodes=args.greedyagg,
+      html_tags_to_exclude={tag for tag in args.excludetags.split(',')},
   )
   passages = chunker.chunk(html)
 


### PR DESCRIPTION
Allow users to modify which html tag text should be excluded from output passages.

Also excludes "html" from <!DOCTYPE html> from appearing in output passages.
