### PR TITLE
Update README.md for dotenv install

### DIFF
--- a/seeds/breadboard/docs/tutorial/README.md
+++ b/seeds/breadboard/docs/tutorial/README.md
@@ -128,7 +128,7 @@ The `secrets` node reaches into our program's environment and gets the environme
 We'll install and use the `dotenv` package, which conveniently reads environment variables from a `.env` file. First, install the package:
 
 ```sh
-npm install.dotenv
+npm install dotenv
 ```
 
 Next, create a `.env` file and put your API key there:


### PR DESCRIPTION
corrects `npm install.dotenv` to `npm install dotenv` (removes `'`, adds space)

Fixes #200

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
