### PR TITLE
Bump node version to 20

### DIFF
--- a/.github/workflows/labs-prototypes-ci.yml
+++ b/.github/workflows/labs-prototypes-ci.yml
@@ -2,36 +2,36 @@ name: Labs Prototypes CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [19.x]
+        node-version: [20.x]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
 
-    - name: Clean Installing dependencies
-      run: npm run ci
+      - name: Clean Installing dependencies
+        run: npm run ci
 
-    - name: Generating the build
-      run: npm run build
+      - name: Generating the build
+        run: npm run build
 
-    - name: Checking the code quality
-      run: npm run lint
+      - name: Checking the code quality
+        run: npm run lint
 
-    - name: Checking the code formatting
-      run: npm run check:format
+      - name: Checking the code formatting
+        run: npm run check:format
 
-    - name: Running tests
-      run: npm run test
+      - name: Running tests
+        run: npm run test


### PR DESCRIPTION
Sometimes the CI/Actions bot has issues getting node19. Since the latest node is actually node20 I figured we could bump to that.