### PR TITLE
[breadboard-web] Update URL to current board

### DIFF
--- a/seeds/breadboard-web/src/ui/ui-controller.ts
+++ b/seeds/breadboard-web/src/ui/ui-controller.ts
@@ -210,6 +210,10 @@ export class UIController extends HTMLElement implements UI {
       return;
     }
 
+    const pageUrl = new URL(window.location.href);
+    pageUrl.searchParams.set("board", url);
+    window.history.replaceState(null, "", pageUrl);
+
     this.#start.setAttribute("url", url);
   }
 


### PR DESCRIPTION
The lack of URL update when changing boards was catching me out, so I made a quick fix for that.