### PR TITLE
Update the tutorial for M3

### DIFF
--- a/seeds/breadboard/docs/tutorial/google-news-headlines.js
+++ b/seeds/breadboard/docs/tutorial/google-news-headlines.js
@@ -8,32 +8,35 @@ import { Board } from "@google-labs/breadboard";
 import { Starter } from "@google-labs/llm-starter";
 import { writeFile } from "fs/promises";
 
-const board = new Board();
-const kit = board.addKit(Starter);
+import * as path from "path";
+import { fileURLToPath } from "url";
+const __dir = path.dirname(fileURLToPath(import.meta.url));
 
-const input = board.input("Enter news topic");
+const board = new Board();
+const starter = board.addKit(Starter);
+
+const input = board.input({ message: "Enter news topic" });
 
 input.wire(
   "topic->query",
-  kit
-    .urlTemplate(
-      "https://news.google.com/rss/search?q={{query}}&hl=en-US&gl=US&ceid=US:en"
-    )
+  starter
+    .urlTemplate({
+      template:
+        "https://news.google.com/rss/search?q={{query}}&hl=en-US&gl=US&ceid=US:en",
+    })
     .wire(
       "url->",
-      kit
-        .fetch(true)
-        .wire(
-          "response->xml",
-          kit
-            .xmlToJson()
-            .wire(
-              "json->",
-              kit
-                .jsonata("$join((rss.channel.item.title.`$t`)[[1..20]], '\n')")
-                .wire("result->headlines", board.output())
-            )
+      starter.fetch({ raw: true }).wire(
+        "response->xml",
+        starter.xmlToJson().wire(
+          "json->",
+          starter
+            .jsonata({
+              expression: "$join((rss.channel.item.title.`$t`)[[1..20]], '\n')",
+            })
+            .wire("result->headlines", board.output())
         )
+      )
     )
 );
 
@@ -41,4 +44,4 @@ const result = await board.runOnce({ topic: "Latest news on breadboards" });
 console.log("result", result);
 
 const json = JSON.stringify(board, null, 2);
-await writeFile("./docs/tutorial/google-news-headlines.json", json);
+await writeFile(path.join(__dir, "google-news-headlines.json"), json);

--- a/seeds/breadboard/docs/tutorial/news-summarizer.json
+++ b/seeds/breadboard/docs/tutorial/news-summarizer.json
@@ -8,20 +8,20 @@
     },
     {
       "from": "secrets-5",
-      "to": "generateText-4",
+      "to": "palm-generateText-4",
       "constant": true,
       "out": "PALM_KEY",
       "in": "PALM_KEY"
     },
     {
-      "from": "generateText-4",
+      "from": "palm-generateText-4",
       "to": "output-6",
       "out": "completion",
       "in": "summary"
     },
     {
       "from": "promptTemplate-1",
-      "to": "generateText-4",
+      "to": "palm-generateText-4",
       "out": "prompt",
       "in": "text"
     },
@@ -43,7 +43,7 @@
       "id": "promptTemplate-1",
       "type": "promptTemplate",
       "configuration": {
-        "template": "Use the news headlines below to write a few sentences tosummarize the latest news on this topic:\n\n##Topic:\n{{topic}}\n\n## Headlines {{headlines}}\n\\n## Summary:\n"
+        "template": "Use the news headlines below to write a few sentences to summarize the latest news on this topic:\n\n##Topic:\n{{topic}}\n\n## Headlines\n{{headlines}}\n\n## Summary:\n"
       }
     },
     {
@@ -58,8 +58,8 @@
       }
     },
     {
-      "id": "generateText-4",
-      "type": "generateText"
+      "id": "palm-generateText-4",
+      "type": "palm-generateText"
     },
     {
       "id": "secrets-5",
@@ -77,7 +77,13 @@
   ],
   "kits": [
     {
+      "url": "npm:@google-labs/core-kit"
+    },
+    {
       "url": "npm:@google-labs/llm-starter"
+    },
+    {
+      "url": "npm:@google-labs/palm-kit"
     }
   ]
 }

--- a/seeds/breadboard/docs/tutorial/tutorial-2.js
+++ b/seeds/breadboard/docs/tutorial/tutorial-2.js
@@ -6,22 +6,24 @@
 
 import { Board } from "@google-labs/breadboard";
 import { Starter } from "@google-labs/llm-starter";
+import { PaLMKit } from "@google-labs/palm-kit";
 import { config } from "dotenv";
 
 config();
 
 const board = new Board();
-// add kit to the board
-const kit = board.addKit(Starter);
+// add kits to the board
+const starter = board.addKit(Starter);
+const palm = board.addKit(PaLMKit);
 
 const input = board.input();
 const output = board.output();
-const generateText = kit.generateText();
+const generateText = palm.generateText();
 
 input.wire("say->text", generateText);
 generateText.wire("completion->hear", output);
 
-const secrets = kit.secrets({ keys: ["PALM_KEY"] });
+const secrets = starter.secrets({ keys: ["PALM_KEY"] });
 
 secrets.wire("PALM_KEY->", generateText);
 

--- a/seeds/breadboard/docs/tutorial/tutorial-3.js
+++ b/seeds/breadboard/docs/tutorial/tutorial-3.js
@@ -6,13 +6,15 @@
 
 import { Board } from "@google-labs/breadboard";
 import { Starter } from "@google-labs/llm-starter";
+import { PaLMKit } from "@google-labs/palm-kit";
 import { config } from "dotenv";
 
 config();
 
 const board = new Board();
-// add kit to the board
-const kit = board.addKit(Starter);
+// add kits to the board
+const starter = board.addKit(Starter);
+const palm = board.addKit(PaLMKit);
 
 const output = board.output();
 board
@@ -20,10 +22,10 @@ board
   .wire("say->", output)
   .wire(
     "say->text",
-    kit
+    palm
       .generateText()
       .wire("completion->hear", output)
-      .wire("<-PALM_KEY", kit.secrets({ keys: ["PALM_KEY"] }))
+      .wire("<-PALM_KEY", starter.secrets({ keys: ["PALM_KEY"] }))
   );
 
 const result = await board.runOnce({

--- a/seeds/breadboard/docs/tutorial/tutorial-4.js
+++ b/seeds/breadboard/docs/tutorial/tutorial-4.js
@@ -4,19 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Board } from "@google-labs/breadboard";
+import { Board, asRuntimeKit } from "@google-labs/breadboard";
 import { Starter } from "@google-labs/llm-starter";
+import { PaLMKit } from "@google-labs/palm-kit";
 import { config } from "dotenv";
 
-import * as path from 'path';
-import { fileURLToPath } from 'url';
+import * as path from "path";
+import { fileURLToPath } from "url";
 const __dir = path.dirname(fileURLToPath(import.meta.url));
 
 config();
 
 const board = new Board();
-// add kit to the board
-const kit = board.addKit(Starter);
+// add kits to the board
+const starter = board.addKit(Starter);
+const palm = board.addKit(PaLMKit);
 
 const output = board.output();
 board
@@ -24,10 +26,10 @@ board
   .wire("say->", output)
   .wire(
     "say->text",
-    kit
+    palm
       .generateText()
       .wire("completion->hear", output)
-      .wire("<-PALM_KEY", kit.secrets({ keys: ["PALM_KEY"] }))
+      .wire("<-PALM_KEY", starter.secrets({ keys: ["PALM_KEY"] }))
   );
 
 const json = JSON.stringify(board, null, 2);
@@ -38,9 +40,14 @@ await writeFile(path.join(__dir, "tutorial-4.json"), json);
 
 const board2 = await Board.load(path.join(__dir, "tutorial-4.json"));
 
-const result = await board2.runOnce({
-  say: "Hi, how are you?",
-});
+const result = await board2.runOnce(
+  {
+    say: "Hi, how are you?",
+  },
+  {
+    kits: [asRuntimeKit(Starter), asRuntimeKit(PaLMKit)],
+  }
+);
 console.log("result", result);
 
 const diagram = board2.mermaid();

--- a/seeds/breadboard/docs/tutorial/tutorial-4.json
+++ b/seeds/breadboard/docs/tutorial/tutorial-4.json
@@ -7,20 +7,20 @@
       "in": "say"
     },
     {
-      "from": "generateText-3",
+      "from": "palm-generateText-3",
       "to": "output-1",
       "out": "completion",
       "in": "hear"
     },
     {
       "from": "secrets-4",
-      "to": "generateText-3",
+      "to": "palm-generateText-3",
       "out": "PALM_KEY",
       "in": "PALM_KEY"
     },
     {
       "from": "input-2",
-      "to": "generateText-3",
+      "to": "palm-generateText-3",
       "out": "say",
       "in": "text"
     }
@@ -35,8 +35,8 @@
       "type": "input"
     },
     {
-      "id": "generateText-3",
-      "type": "generateText"
+      "id": "palm-generateText-3",
+      "type": "palm-generateText"
     },
     {
       "id": "secrets-4",
@@ -51,6 +51,9 @@
   "kits": [
     {
       "url": "npm:@google-labs/llm-starter"
+    },
+    {
+      "url": "npm:@google-labs/palm-kit"
     }
   ]
 }

--- a/seeds/breadboard/docs/tutorial/tutorial-5.js
+++ b/seeds/breadboard/docs/tutorial/tutorial-5.js
@@ -5,34 +5,39 @@
  */
 
 import { Board } from "@google-labs/breadboard";
+import { Core } from "@google-labs/core-kit";
 import { Starter } from "@google-labs/llm-starter";
+import { PaLMKit } from "@google-labs/palm-kit";
 
 import { config } from "dotenv";
 
 config();
 
 const board = new Board();
-const kit = board.addKit(Starter);
+const core = board.addKit(Core);
+const starter = board.addKit(Starter);
+const palm = board.addKit(PaLMKit);
 
 const NEWS_BOARD_URL =
-  "https://gist.githubusercontent.com/dglazkov/55db9bb36acd5ba5cfbd82d2901e7ced/raw/google-news-headlines.json";
+  "https://raw.githubusercontent.com/google/labs-prototypes/main/seeds/breadboard/docs/tutorial/news-summarizer.json";
 
-const template = kit.promptTemplate(
-  "Use the news headlines below to write a few sentences to" +
+const template = starter.promptTemplate({
+  template:
+    "Use the news headlines below to write a few sentences to " +
     "summarize the latest news on this topic:\n\n##Topic:\n" +
-    "{{topic}}\n\n## Headlines {{headlines}}\n\\n## Summary:\n"
-);
+    "{{topic}}\n\n## Headlines\n{{headlines}}\n\n## Summary:\n",
+});
 
 const input = board.input();
 input.wire(
   "say->topic",
-  board.include(NEWS_BOARD_URL).wire(
+  core.include({ path: NEWS_BOARD_URL }).wire(
     "headlines->",
     template.wire("topic<-say", input).wire(
       "prompt->text",
-      kit
+      palm
         .generateText()
-        .wire("<-PALM_KEY.", kit.secrets({ keys: ["PALM_KEY"] }))
+        .wire("<-PALM_KEY.", starter.secrets({ keys: ["PALM_KEY"] }))
         .wire("completion->say", board.output())
     )
   )

--- a/seeds/breadboard/docs/tutorial/tutorial-6a.js
+++ b/seeds/breadboard/docs/tutorial/tutorial-6a.js
@@ -5,36 +5,42 @@
  */
 
 import { Board } from "@google-labs/breadboard";
+import { Core } from "@google-labs/core-kit";
 import { Starter } from "@google-labs/llm-starter";
+import { PaLMKit } from "@google-labs/palm-kit";
+
 import { writeFile } from "fs/promises";
 
 import { config } from "dotenv";
 
-import * as path from 'path';
-import { fileURLToPath } from 'url';
+import * as path from "path";
+import { fileURLToPath } from "url";
 const __dir = path.dirname(fileURLToPath(import.meta.url));
 
 config();
 
 const board = new Board();
-const kit = board.addKit(Starter);
+const core = board.addKit(Core);
+const starter = board.addKit(Starter);
+const palm = board.addKit(PaLMKit);
 
-const template = kit.promptTemplate(
-  "Use the news headlines below to write a few sentences to" +
+const template = starter.promptTemplate({
+  template:
+    "Use the news headlines below to write a few sentences to " +
     "summarize the latest news on this topic:\n\n##Topic:\n" +
-    "{{topic}}\n\n## Headlines {{headlines}}\n\\n## Summary:\n"
-);
+    "{{topic}}\n\n## Headlines\n{{headlines}}\n\n## Summary:\n",
+});
 
 const input = board.input();
 input.wire(
   "topic->",
-  board.slot("news").wire(
+  core.slot({ slot: "news" }).wire(
     "headlines->",
     template.wire("topic<-", input).wire(
       "prompt->text",
-      kit
+      palm
         .generateText()
-        .wire("<-PALM_KEY.", kit.secrets({ keys: ["PALM_KEY"] }))
+        .wire("<-PALM_KEY.", starter.secrets({ keys: ["PALM_KEY"] }))
         .wire("completion->summary", board.output())
     )
   )

--- a/seeds/breadboard/docs/tutorial/tutorial-6b.js
+++ b/seeds/breadboard/docs/tutorial/tutorial-6b.js
@@ -4,21 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Board } from "@google-labs/breadboard";
+import { Board, asRuntimeKit } from "@google-labs/breadboard";
+import { Core } from "@google-labs/core-kit";
+import { Starter } from "@google-labs/llm-starter";
+import { PaLMKit } from "@google-labs/palm-kit";
 
 import { config } from "dotenv";
 
 config();
 
 const NEWS_SUMMARIZER_URL =
-  "https://gist.githubusercontent.com/dglazkov/dd3f071260a1c3b97aa81beac6045da3/raw/news-summarizer.json";
+  "https://raw.githubusercontent.com/google/labs-prototypes/main/seeds/breadboard/docs/tutorial/news-summarizer.json";
 
 const NEWS_BOARD_URL =
-  "https://gist.githubusercontent.com/dglazkov/55db9bb36acd5ba5cfbd82d2901e7ced/raw/google-news-headlines.json";
+  "https://raw.githubusercontent.com/google/labs-prototypes/main/seeds/breadboard/docs/tutorial/google-news-headlines.json";
 
 const news = await Board.load(NEWS_BOARD_URL);
 
 const board = await Board.load(NEWS_SUMMARIZER_URL, { slotted: { news } });
 
-const result = await board.runOnce({ topic: "Latest news on breadboards" });
+const result = await board.runOnce(
+  { topic: "Latest news on breadboards" },
+  { kits: [asRuntimeKit(Core), asRuntimeKit(Starter), asRuntimeKit(PaLMKit)] }
+);
 console.log("result", result);

--- a/seeds/breadboard/docs/tutorial/tutorial-7a.js
+++ b/seeds/breadboard/docs/tutorial/tutorial-7a.js
@@ -6,13 +6,16 @@
 
 import { Board, LogProbe } from "@google-labs/breadboard";
 import { Starter } from "@google-labs/llm-starter";
+import { PaLMKit } from "@google-labs/palm-kit";
+
 import { config } from "dotenv";
 
 config();
 
 const board = new Board();
-// add kit to the board
-const kit = board.addKit(Starter);
+// add kits to the board
+const starter = board.addKit(Starter);
+const palm = board.addKit(PaLMKit);
 
 const output = board.output();
 board
@@ -20,17 +23,14 @@ board
   .wire("say->", output)
   .wire(
     "say->text",
-    kit
+    palm
       .generateText()
       .wire("completion->hear", output)
-      .wire("<-PALM_KEY", kit.secrets({ keys: ["PALM_KEY"] }))
+      .wire("<-PALM_KEY", starter.secrets({ keys: ["PALM_KEY"] }))
   );
 
 const result = await board.runOnce(
-  {
-    say: "Hi, how are you?",
-  },
-  undefined,
-  new LogProbe()
+  { say: "Hi, how are you?" },
+  { probe: new LogProbe() }
 );
 console.log("result", result);

--- a/seeds/breadboard/docs/tutorial/tutorial-7b.js
+++ b/seeds/breadboard/docs/tutorial/tutorial-7b.js
@@ -6,13 +6,16 @@
 
 import { Board } from "@google-labs/breadboard";
 import { Starter } from "@google-labs/llm-starter";
+import { PaLMKit } from "@google-labs/palm-kit";
+
 import { config } from "dotenv";
 
 config();
 
 const board = new Board();
-// add kit to the board
-const kit = board.addKit(Starter);
+// add kits to the board
+const starter = board.addKit(Starter);
+const palm = board.addKit(PaLMKit);
 
 const output = board.output();
 board
@@ -20,24 +23,20 @@ board
   .wire("say->", output)
   .wire(
     "say->text",
-    kit
+    palm
       .generateText()
       .wire("completion->hear", output)
-      .wire("<-PALM_KEY", kit.secrets({ keys: ["PALM_KEY"] }))
+      .wire("<-PALM_KEY", starter.secrets({ keys: ["PALM_KEY"] }))
   );
 
 const probe = new EventTarget();
 
 probe.addEventListener("node", (event) => {
   const data = event.detail;
-  if (data.descriptor.type == "generateText") {
+  if (data.descriptor.type == "palm-generateText") {
     console.log("completion:", data.outputs.completion);
   }
 });
 
-const result = await board.runOnce(
-  { say: "Hi, how are you?" },
-  undefined,
-  probe
-);
+const result = await board.runOnce({ say: "Hi, how are you?" }, { probe });
 console.log("result", result);

--- a/seeds/breadboard/docs/tutorial/tutorial-8.js
+++ b/seeds/breadboard/docs/tutorial/tutorial-8.js
@@ -6,21 +6,24 @@
 
 import { Board } from "@google-labs/breadboard";
 import { Starter } from "@google-labs/llm-starter";
+import { PaLMKit } from "@google-labs/palm-kit";
+
 import { config } from "dotenv";
 
 config();
 
 const board = new Board();
 // add kit to the board
-const kit = board.addKit(Starter);
+const starter = board.addKit(Starter);
+const palm = board.addKit(PaLMKit);
 
 const output = board.output();
 board.input().wire(
   "say->text",
-  kit
+  palm
     .generateText()
     .wire("completion->hear", output)
-    .wire("<-PALM_KEY", kit.secrets({ keys: ["PALM_KEY"] }))
+    .wire("<-PALM_KEY", starter.secrets({ keys: ["PALM_KEY"] }))
 );
 
 for await (const stop of board.run()) {

--- a/seeds/breadboard/docs/tutorial/tutorial-9.js
+++ b/seeds/breadboard/docs/tutorial/tutorial-9.js
@@ -9,30 +9,35 @@ import { stdin, stdout } from "node:process";
 import { config } from "dotenv";
 
 import { Board } from "@google-labs/breadboard";
+import { Core } from "@google-labs/core-kit";
 import { Starter } from "@google-labs/llm-starter";
+import { PaLMKit } from "@google-labs/palm-kit";
 
 config();
 
 const board = new Board();
-const kit = board.addKit(Starter);
+const core = board.addKit(Core);
+const starter = board.addKit(Starter);
+const palm = board.addKit(PaLMKit);
 
 const input = board.input();
 const output = board.output();
 output.wire("->", input);
 
-const history = kit.append();
+const history = core.append();
 history.wire("accumulator->?", history);
 input.wire("say->user", history);
 
-const completion = kit
+const completion = palm
   .generateText()
   .wire("completion->hear", output)
   .wire("completion->assistant", history)
-  .wire("<-PALM_KEY.", kit.secrets({ keys: ["PALM_KEY"] }));
+  .wire("<-PALM_KEY.", starter.secrets({ keys: ["PALM_KEY"] }));
 
-kit
-  .promptTemplate(
-    "This is a conversation between a friendly assistant and their user.\n" +
+starter
+  .promptTemplate({
+    template:
+      "This is a conversation between a friendly assistant and their user.\n" +
       "You are the assistant and your job is to try to be helpful,\n" +
       "empathetic, and fun.\n\n" +
       "== Conversation History\n" +
@@ -40,13 +45,13 @@ kit
       "== Current Conversation\n" +
       "user: {{question}}\n" +
       "assistant:",
-    { context: "" }
-  )
+    context: "",
+  })
   .wire("prompt->text", completion)
   .wire("question<-say", input)
   .wire("context<-accumulator", history);
 
-board.passthrough().wire("->", input);
+core.passthrough().wire("->", input);
 
 const ask = readline.createInterface({ input: stdin, output: stdout });
 console.log("Hello! I'm your friendly assistant. How can I help you today?");

--- a/seeds/llm-starter/src/nodes/prompt-template.ts
+++ b/seeds/llm-starter/src/nodes/prompt-template.ts
@@ -61,7 +61,7 @@ export const promptTemplateHandler: NodeHandlerFunction = async (
 };
 
 export const computeInputSchema = (inputs: InputValues): Schema => {
-  const parameters = parametersFromTemplate((inputs.template ?? '') as string);
+  const parameters = parametersFromTemplate((inputs.template ?? "") as string);
   const properties: Schema["properties"] = parameters.reduce(
     (acc, parameter) => {
       const schema = {


### PR DESCRIPTION
The main changes were:

1. `generateText` moved from `starter-kit` to `palm-kit`
2. `append` moved from `starter-kit` to `core-kit`
3. `include` and `passthrough` moved from `Board` to `core-kit`
4. Nodes are typically now configured with objects instead of plain parameters (e.g. `promptTemplate("foo")` is now `promptTemplate({template: "foo})`.)
5. `asRuntimeKit` was added where needed
6. Changed URLs of remote JSON boards to the GitHub raw endpoint for this repo, instead of Gists, so that it's easy to update them by pushing to this repo.

Fixes https://github.com/google/labs-prototypes/issues/199