### PR TITLE
Start using Wireit

### DIFF
--- a/.github/workflows/labs-prototypes-ci.yml
+++ b/.github/workflows/labs-prototypes-ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
+      - uses: google/wireit@setup-github-actions-caching/v1
 
       - name: Clean Installing dependencies
         run: npm run ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,13 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - uses: google/wireit@setup-github-actions-caching/v1
       - run: npm install
       - run: npm run build
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          registry-url: 'https://wombat-dressing-room.appspot.com/'
+          registry-url: "https://wombat-dressing-room.appspot.com/"
       - name: npm publish
         run: |
           cd seeds/palm-lite/

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,5 @@ dist
 *.local.ts
 *.local.json
 *.local.md
+
+.wireit

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "npm-ci": "^0.0.2",
         "rimraf": "^5.0.1",
         "turbo": "1.10.15",
-        "typescript": "^5.0.4"
+        "typescript": "^5.0.4",
+        "wireit": "^0.14.1"
       }
     },
     "core/tsconfig": {
@@ -798,6 +799,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -16295,6 +16297,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/proto3-json-serializer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.1.1.tgz",
@@ -19773,6 +19795,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wireit": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.1.tgz",
+      "integrity": "sha512-q5sixPM/vKQEpyaub6J9QoHAFAF9g4zBdnjoYelH9/RLAekcUf3x1dmFLACGZ6nYjqehCsTlXC1irmzU7znPhA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "chokidar": "^3.5.3",
+        "fast-glob": "^3.2.11",
+        "jsonc-parser": "^3.0.0",
+        "proper-lockfile": "^4.1.2"
+      },
+      "bin": {
+        "wireit": "bin/wireit.js"
+      },
+      "engines": {
+        "node": ">=14.14.0"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "npm-ci": "^0.0.2",
     "rimraf": "^5.0.1",
     "turbo": "1.10.15",
-    "typescript": "^5.0.4"
+    "typescript": "^5.0.4",
+    "wireit": "^0.14.1"
   },
   "workspaces": [
     "./core/*",

--- a/seeds/breadboard/package.json
+++ b/seeds/breadboard/package.json
@@ -12,13 +12,98 @@
   "types": "dist/src/index.d.ts",
   "type": "module",
   "scripts": {
-    "generate:docs": "typedoc --plugin typedoc-plugin-markdown",
-    "test": "FORCE_COLOR=1 ava",
-    "build": "FORCE_COLOR=1 tsc --b && npm run build:rollup",
-    "build:rollup": "rollup -c",
-    "watch": "FORCE_COLOR=1 tsc --b --watch",
-    "lint": "FORCE_COLOR=1 eslint . --ext .ts",
-    "merm": "npm run build && node scripts/make-graphs.js"
+    "generate:docs": "wireit",
+    "test": "wireit",
+    "build": "wireit",
+    "build:tsc": "wireit",
+    "build:rollup": "wireit",
+    "lint": "wireit",
+    "merm": "wireit"
+  },
+  "wireit": {
+    "build": {
+      "dependencies": [
+        "build:rollup",
+        "build:tsc"
+      ]
+    },
+    "build:tsc": {
+      "command": "tsc -b",
+      "env": {
+        "FORCE_COLOR": "1"
+      },
+      "files": [
+        "src/**/*.ts",
+        "tests/**/*.ts",
+        "tsconfig.json",
+        "../tsconfig/base.json"
+      ],
+      "output": [
+        "dist/",
+        "!dist/**/*.min.js{,.map}"
+      ],
+      "clean": "if-file-deleted"
+    },
+    "build:rollup": {
+      "command": "rollup -c",
+      "dependencies": [
+        "build:tsc"
+      ],
+      "files": [
+        "rollup.config.js",
+        "package.json"
+      ],
+      "output": [
+        "dist/**/*.min.js{,.map}"
+      ]
+    },
+    "test": {
+      "command": "ava",
+      "env": {
+        "FORCE_COLOR": "1"
+      },
+      "dependencies": [
+        "build:tsc"
+      ],
+      "files": [],
+      "output": []
+    },
+    "lint": {
+      "command": "eslint . --ext .ts",
+      "env": {
+        "FORCE_COLOR": "1"
+      },
+      "files": [
+        "src/**/*.ts",
+        "tests/**/*.ts",
+        ".eslintrc"
+      ],
+      "output": []
+    },
+    "merm": {
+      "command": "node scripts/make-graphs.js",
+      "dependencies": [
+        "build:tsc"
+      ],
+      "files": [
+        "scripts/make-graphs.js",
+        "tests/data/**/*.json"
+      ],
+      "output": [
+        "docs/graphs/**/*.md"
+      ]
+    },
+    "generate:docs": {
+      "command": "typedoc --plugin typedoc-plugin-markdown",
+      "files": [
+        "src/**/*.ts",
+        "tsconfig.json",
+        "../tsconfig/base.json"
+      ],
+      "output": [
+        "docs/api/"
+      ]
+    }
   },
   "repository": {
     "type": "git",

--- a/seeds/core-kit/package.json
+++ b/seeds/core-kit/package.json
@@ -7,10 +7,58 @@
   "types": "dist/src/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "FORCE_COLOR=1 tsc --b",
-    "test": "FORCE_COLOR=1 ava",
-    "watch": "FORCE_COLOR=1 tsc --b --watch",
-    "lint": "FORCE_COLOR=1 eslint . --ext .ts"
+    "build": "wireit",
+    "test": "wireit",
+    "lint": "wireit"
+  },
+  "wireit": {
+    "build": {
+      "dependencies": [
+        "../breadboard:build",
+        "build:tsc"
+      ]
+    },
+    "build:tsc": {
+      "command": "tsc -b",
+      "env": {
+        "FORCE_COLOR": "1"
+      },
+      "dependencies": [
+        "../breadboard:build:tsc"
+      ],
+      "files": [
+        "src/**/*.ts",
+        "tests/**/*.ts",
+        "tsconfig.json",
+        "../tsconfig/base.json"
+      ],
+      "output": [
+        "dist/"
+      ],
+      "clean": "if-file-deleted"
+    },
+    "test": {
+      "command": "ava",
+      "env": {
+        "FORCE_COLOR": "1"
+      },
+      "dependencies": [
+        "build:tsc"
+      ],
+      "files": [],
+      "output": []
+    },
+    "lint": {
+      "command": "eslint . --ext .ts",
+      "env": {
+        "FORCE_COLOR": "1"
+      },
+      "files": [
+        "src/**/*.ts",
+        "tests/**/*.ts"
+      ],
+      "output": []
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
[Wireit](https://github.com/google/wireit) is a build and service orchestration tool for npm. It's similar to Turbo, but I believe it's easier to understand and more powerful. One of the main motivations was to bring over my favorite features of Bazel to the npm ecosystem. It's used extensively in the [Lit monorepo](https://github.com/lit/lit), plus a bunch of [other projects](https://github.com/google/wireit/network/dependents) (like Puppeteer).

**Disclaimer**: I created Wireit.

This PR installs Wireit, converts the `breadboard` and `core-kit` packages, and sets up GitHub Actions CI caching. If we're in agreement to move forward, I'll send another PR as a followup that converts the rest of the packages, and removes Turbo.

Here are some advantages we'll get:

1. It makes the npm scripts themselves smarter, instead of layering new commands on-top. So you just run your e.g. `npm run build` or `npm test` from any sub-package or the top-level like normal, but now all of those script's dependencies will be automatically built first, and any build steps that are already fresh will get skipped. There's no "do I run this script directly, or with Turbo?" distinction; every script is just always smart.

    It also works at *script* granularity, meaning you can say e.g. "this script depends on the typescript output, but not the rollup output", as opposed to *package* granularity where you typically have to build the entire package, even if the specific script you're running only needs a subset of that package's build artifacts.

2. Universal watch mode. You can append `--watch` to any `npm run` or `npm test` command, and it will automatically re-run whenever any of its files change, or any of its dependencies need to rebuild.

    This is usually nicer than the built-in watch modes that various tools have, because it makes them aware of the entire build graph. For example a test runner's built-in watch mode will notice when there are new input `.js` files, but it's not going to automatically re-run `tsc` when a `.ts` file changes -- so that means you usually have to run multiple watchers, which (A) is less convenient, and (B) sometimes causes problems where the second watch script doesn't realize the first one hasn't finished yet, causing double builds.

3. Caching on GitHub Actions. Build artifacts get restored from cache in CI instead of being rebuilt whenever possible, and tests who passed last time and whose transitive inputs have not changed will be skipped. Turbo also supports caching on CI, but only through their own cloud services. Wireit instead uses the caching mechanism that GitHub itself provides for GitHub actions.

4. *Services*. Wireit lets you describe a server that depends on some build steps, including describing "if these files change, you need to restart the server, but if these other files change, you don't". So, if you have a dev server, you can run it with `--watch` and then go change anything anywhere in the monorepo, and have those changes reflected automatically.

5. Unopinionated about layout and supports incremental adoption. Wireit isn't a "monorepo manager" like some similar tools -- it doesn't care how you lay out your packages, since cross-package dependencies are declared explicitly with relative paths (e.g. `../other-package:build:tsc`). Also, if you're a wireit script, it doesn't matter if your dependencies or dependents are also wireit scripts -- you can adopt wireit incrementally on a per script or per package basis.

Downsides:

1. To work best, Wireit requires you to describe all of your input and output files for each script, as you'll see in this PR. And sometimes it can be a little tricky to work out exactly what a scripts input and output files are. But in return, you get a really fast and well integrated build graph!

Part of https://github.com/google/labs-prototypes/issues/148