### PR TITLE
[breadboard-cli-tools] Can now import typescript, and hot-reload

### DIFF
--- a/seeds/breadboard-cli-tools/package.json
+++ b/seeds/breadboard-cli-tools/package.json
@@ -123,6 +123,7 @@
   "dependencies": {
     "@google-labs/breadboard": "*",
     "commander": "^11.1.0",
+    "esbuild": "^0.19.9",
     "serve": "^14.2.1"
   }
 }

--- a/seeds/breadboard-cli-tools/src/commands/make-graph.ts
+++ b/seeds/breadboard-cli-tools/src/commands/make-graph.ts
@@ -4,37 +4,67 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { watch } from 'fs';
-import path from 'path';
-import { loadBoardFromModule, resolveFilePath } from './lib/utils.js';
+import { watch } from "fs";
+import { stat } from "fs/promises";
+import path from "path";
+import { resolveFilePath } from "./lib/utils.js";
+import { makeFromFile } from "./lib/utils.js";
 
-export const makeGraph = async (file: string, options: Record<string, string>) => {
+export const makeGraph = async (
+  file: string,
+  options: Record<string, string>
+) => {
   const filePath = resolveFilePath(file);
 
-  if (file != undefined) {
-    if (path.extname(file) != '.js') {
-      throw new Error(`File ${file} is not a JavaScript file.`);
-    }
+  if (
+    file != undefined &&
+    path.extname(file) == ".ts" &&
+    "output" in options == false
+  ) {
+    throw new Error(
+      `File ${file} is not a TypeScript file. You must specify the output directory with --output.`
+    );
+  }
 
-    const controller = new AbortController();
-    let board = await loadBoardFromModule(filePath);
-
-    console.log(JSON.stringify(board, null, 2));
-
-    if ('watch' in options) {
-      watch(file, { signal: controller.signal }, async (eventType: string, filename: string | Buffer | null) => {
-        if (typeof (filename) != 'string') return;
-
-        if (eventType === 'change') {
-          board = await loadBoardFromModule(filePath);
-
-          console.log(JSON.stringify(board, null, 2));
-        }
-        else if (eventType === 'rename') {
-          console.error(`File ${filename} has been renamed. We can't manage this yet. Sorry!`);
-          controller.abort();
-        }
-      });
+  if (file != undefined && path.extname(file) == ".ts" && options["output"]) {
+    const fullDirPath = path.resolve(process.cwd(), options["output"]);
+    const dirStat = await stat(fullDirPath);
+    if (dirStat.isDirectory() == false) {
+      throw new Error(
+        `The path specified by ${options["output"]} is not a directory.`
+      );
     }
   }
-}
+
+  if (file != undefined && path.extname(file) != ".js" && path.extname(file) != ".ts") {
+    throw new Error(`File ${file} must be JavaScript or a TypeScript file.`);
+  }
+
+  if (file != undefined) {
+    let { boardJson } = await makeFromFile(filePath, options);
+
+    console.log(boardJson, null, 2);
+
+    if ("watch" in options) {
+      const controller = new AbortController();
+      watch(
+        file,
+        { signal: controller.signal },
+        async (eventType: string, filename: string | Buffer | null) => {
+          if (typeof filename != "string") return;
+
+          if (eventType === "change") {
+            ({ boardJson } = await makeFromFile(filePath));
+
+            console.log(JSON.stringify(boardJson, null, 2));
+          } else if (eventType === "rename") {
+            console.error(
+              `File ${filename} has been renamed. We can't manage this yet. Sorry!`
+            );
+            controller.abort();
+          }
+        }
+      );
+    }
+  }
+};

--- a/seeds/breadboard-cli-tools/src/commands/mermaid.ts
+++ b/seeds/breadboard-cli-tools/src/commands/mermaid.ts
@@ -4,39 +4,60 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BoardRunner } from '@google-labs/breadboard';
-import { watch } from 'fs';
-import { loadBoard, parseStdin, resolveFilePath } from './lib/utils.js';
+import { BoardRunner } from "@google-labs/breadboard";
+import { watch } from "fs";
+import { loadBoard, parseStdin, resolveFilePath } from "./lib/utils.js";
+import path from "path";
 
-export const mermaid = async (file: string, options: Record<string, string>) => {
+export const mermaid = async (
+  file: string,
+  options: Record<string, string>
+) => {
+
+  if (
+    file != undefined &&
+    path.extname(file) == ".ts" &&
+    "output" in options == false
+  ) {
+    throw new Error(
+      `File ${file} is a TypeScript file. You must specify the output directory with --output.`
+    );
+  }
+
   if (file != undefined) {
     const filePath = resolveFilePath(file);
-    let board = await loadBoard(filePath);
+    let board = await loadBoard(filePath, options);
+
     console.log(board.mermaid());
 
-    if ('watch' in options) {
+    if ("watch" in options) {
       const controller = new AbortController();
 
-      watch(file, { signal: controller.signal }, async (eventType: string, filename: string | Buffer | null) => {
-        if (typeof (filename) != 'string') return;
+      watch(
+        file,
+        { signal: controller.signal },
+        async (eventType: string, filename: string | Buffer | null) => {
+          if (typeof filename != "string") return;
 
-        if (eventType === 'change') {
-          board = await loadBoard(filePath);
-          console.log(board.mermaid());
+          if (eventType === "change") {
+            board = await loadBoard(filePath, options);
+            console.log(board.mermaid());
+          } else if (eventType === "rename") {
+            console.error(
+              `File ${filename} has been renamed. We can't manage this yet. Sorry!`
+            );
+            controller.abort();
+          }
         }
-        else if (eventType === 'rename') {
-          console.error(`File ${filename} has been renamed. We can't manage this yet. Sorry!`);
-          controller.abort();
-        }
-      });
+      );
     }
-  }
-  else {
+  } else {
     const stdin = await parseStdin();
-   
+
+    // TODO: What do we do if it's typescript?
     // We should validate it looks like a board...
     const board = await BoardRunner.fromGraphDescriptor(JSON.parse(stdin));
 
     console.log(board.mermaid());
   }
-}
+};

--- a/seeds/breadboard-cli-tools/src/index.ts
+++ b/seeds/breadboard-cli-tools/src/index.ts
@@ -18,18 +18,21 @@ program
 
 program
   .command("debug [file]")
+  .option("-o, --output <path>", "If compiling a graph in Typescript (.ts), you MUST specific a location to output the compiled graph.")
   .description("Starts a simple HTTP server that serves the breadboard-web app, and outputs a URL that contains a link to a breadboard file that the user provided.")
   .action(debug);
 
 program
   .command("mermaid [file]")
   .description("Watch a breadboard file and output the mermaid diagram when it changes.")
+  .option("-o, --output <path>", "If compiling a graph in Typescript (.ts), you MUST specific a location to output the compiled graph.")
   .option("-w, --watch", "Watch the file for changes.")
   .action(mermaid)
 
 program
   .command("make [file]")
   .description("Make a graph from a javascript file. Note:all the imports have to be resolvable from the current directory.")
+  .option("-o, --output <path>", "If compiling a graph in Typescript (.ts), you MUST specific a location to output the compiled graph.")
   .option("-w, --watch", "Watch the file for changes.")
   .action(makeGraph)
 
@@ -37,8 +40,12 @@ program
   .command("run [file]")
   .description("Run a graph.")
   .option("-w, --watch", "Watch the file for changes.")
+  .option("-o, --output <path>", "If compiling a graph in Typescript (.ts), you MUST specific a location to output the compiled graph.")
   .option("-k, --kit <kit...>", "The kit to use.")
   .option("-i, --input <input>", "The JSON that represents the input to the graph.")
   .action(run)
 
 program.parse();
+
+// Allow developers to integrate with the CLI
+export { debug, mermaid, makeGraph, run };


### PR DESCRIPTION
@dglazkov - (just an FYI using a branch so I can see if I broke the build). Hot module reload for CLI tools for you.  Still working on it for `debug` (which uses breadboard-web)