### PR TITLE
[team-exp] Support prefilled parts for multimodal input

### DIFF
--- a/seeds/team-experiments/src/events/events.ts
+++ b/seeds/team-experiments/src/events/events.ts
@@ -44,10 +44,10 @@ export class TeamSectionSelectEvent extends Event {
   }
 }
 
-export class MultiModalInputEvent extends Event {
-  static readonly eventName = "multimodalinput";
+export class MultiPartInputEvent extends Event {
+  static readonly eventName = "multipartinput";
 
   constructor(public parts: ConversationInputPart[]) {
-    super(MultiModalInputEvent.eventName, { ...opts });
+    super(MultiPartInputEvent.eventName, { ...opts });
   }
 }

--- a/seeds/team-experiments/src/ui/elements/conversation/conversation.ts
+++ b/seeds/team-experiments/src/ui/elements/conversation/conversation.ts
@@ -18,7 +18,7 @@ import { toRelativeTime } from "../../utils/toRelativeTime.js";
 import { cache } from "lit/directives/cache.js";
 import {
   ConversationItemCreateEvent,
-  MultiModalInputEvent,
+  MultiPartInputEvent,
 } from "../../../events/events.js";
 import { Ref, createRef, ref } from "lit/directives/ref.js";
 
@@ -526,7 +526,8 @@ export class Conversation extends LitElement {
               if (item.format === ItemFormat.MULTIPART) {
                 return html`<at-multi-modal-input
                   .inputTitle=${item.title}
-                  @multimodalinput=${(evt: MultiModalInputEvent) => {
+                  .parts=${item.parts}
+                  @multipartinput=${(evt: MultiPartInputEvent) => {
                     this.dispatchEvent(
                       new ConversationItemCreateEvent(evt.parts)
                     );

--- a/seeds/team-experiments/src/ui/elements/conversation/multi-part-input.ts
+++ b/seeds/team-experiments/src/ui/elements/conversation/multi-part-input.ts
@@ -9,10 +9,10 @@ import { ConversationInputPart } from "../../../types/types.js";
 import { map } from "lit/directives/map.js";
 import { classMap } from "lit/directives/class-map.js";
 import { asBase64 } from "../../utils/asBase64.js";
-import { MultiModalInputEvent } from "../../../events/events.js";
+import { MultiPartInputEvent } from "../../../events/events.js";
 
-@customElement("at-multi-modal-input")
-export class MultiModalInput extends LitElement {
+@customElement("at-multi-part-input")
+export class MultiPartInput extends LitElement {
   @property()
   inputTitle: string | null = null;
 
@@ -185,18 +185,14 @@ export class MultiModalInput extends LitElement {
 
   #items: ConversationInputPart[] = [];
 
-  set value(value: string) {
-    this.#items = JSON.parse(value);
-  }
-
-  get value() {
-    return JSON.stringify(this.#items);
+  set parts(parts: ConversationInputPart[]) {
+    this.#items = [...parts];
   }
 
   #onSubmit(evt: SubmitEvent) {
     evt.preventDefault();
 
-    this.dispatchEvent(new MultiModalInputEvent(this.#items));
+    this.dispatchEvent(new MultiPartInputEvent(this.#items));
   }
 
   render() {
@@ -279,7 +275,7 @@ export class MultiModalInput extends LitElement {
               type="button"
               id="skip"
               @click=${() => {
-                this.dispatchEvent(new MultiModalInputEvent([]));
+                this.dispatchEvent(new MultiPartInputEvent([]));
               }}
             >
               Skip

--- a/seeds/team-experiments/src/ui/elements/elements.ts
+++ b/seeds/team-experiments/src/ui/elements/elements.ts
@@ -6,7 +6,7 @@
 
 export { AssetsList } from "./assets-list/assets-list.js";
 export { Conversation } from "./conversation/conversation.js";
-export { MultiModalInput } from "./conversation/multi-modal-input.js";
+export { MultiPartInput } from "./conversation/multi-part-input.js";
 export { Switcher } from "./switcher/switcher.js";
 export { TeamActivity } from "./team-activity/team-activity.js";
 export { TeamJob } from "./team-job/team-job.js";


### PR DESCRIPTION
Now something like this prefills the selector with the item provided.

```javascript
{
  datetime: new Date(performance.timeOrigin),
  type: ItemType.INPUT,
  format: ItemFormat.MULTIPART,
  title: "Share your logo and brand examples",
  parts: [
    {
      inline_data: { mime_type: "text/plain", data: btoa("Value") },
      name: "Your file",
      url: "#",
    },
  ],
}
```