### PR TITLE
Add functionality to exclude certain classes from being chunked

### DIFF
--- a/seeds/chunker-python/src/google_labs_html_chunker/html_chunker.py
+++ b/seeds/chunker-python/src/google_labs_html_chunker/html_chunker.py
@@ -17,6 +17,9 @@ import bs4
 # Text within these html tags will be excluded from passages by default.
 _DEFAULT_HTML_TAGS_TO_EXCLUDE = frozenset({"noscript", "script", "style"})
 
+# Text within these html classes will be excluded from passages by default.
+_DEFAULT_HTML_CLASSES_TO_EXCLUDE = frozenset({})
+
 # Html tags that indicate a section break. Sibling nodes will not be
 # greedily-aggregated into a chunk across one of these tags.
 _SECTION_BREAK_HTML_TAGS = frozenset({
@@ -56,6 +59,9 @@ class HtmlChunker:
     html_tags_to_exclude: Text within any of the tags in this set will not be
       included in the output passages. Defaults to {"noscript", "script",
       "style"}.
+    html_classes_to_exclude: Text within any of the classes in this set will not be
+      included in the output passages. Defaults to {"noscript", "script",
+      "style"}.
   """
 
   def __init__(
@@ -63,12 +69,14 @@ class HtmlChunker:
       max_words_per_aggregate_passage: int,
       greedily_aggregate_sibling_nodes: bool,
       html_tags_to_exclude: frozenset[str] = _DEFAULT_HTML_TAGS_TO_EXCLUDE,
+      html_classes_to_exclude: frozenset[str] = _DEFAULT_HTML_CLASSES_TO_EXCLUDE,
   ) -> None:
     self.max_words_per_aggregate_passage = max_words_per_aggregate_passage
     self.greedily_aggregate_sibling_nodes = greedily_aggregate_sibling_nodes
     self.html_tags_to_exclude = {
         tag.strip().lower() for tag in html_tags_to_exclude
     }
+    self.html_classes_to_exclude = {class_.strip().lower() for class_ in html_classes_to_exclude}
 
   class PassageList:
     """A list of text passages."""
@@ -134,7 +142,13 @@ class HtmlChunker:
     current_node = self.AggregateNode()
     if node.name:
       current_node.html_tag = node.name
-    if node.name in self.html_tags_to_exclude or isinstance(node, bs4.Comment):
+    if (node.name in self.html_tags_to_exclude 
+      or isinstance(node, bs4.Comment)
+      or (
+          not isinstance(node, bs4.NavigableString)
+          and any(cls in self.html_classes_to_exclude for cls in node.get("class", []))
+        )
+      ):
       # Exclude text within these tags.
       return current_node
 

--- a/seeds/chunker-python/src/google_labs_html_chunker/html_chunker.py
+++ b/seeds/chunker-python/src/google_labs_html_chunker/html_chunker.py
@@ -60,8 +60,7 @@ class HtmlChunker:
       included in the output passages. Defaults to {"noscript", "script",
       "style"}.
     html_classes_to_exclude: Text within any of the classes in this set will not be
-      included in the output passages. Defaults to {"noscript", "script",
-      "style"}.
+      included in the output passages.
   """
 
   def __init__(


### PR DESCRIPTION
This pull request introduces the ability to exclude specific HTML classes from the text chunking process:
   - Added a new parameter `_DEFAULT_HTML_CLASSES_TO_EXCLUDE` that allows users to define which HTML classes should be excluded by default.
   - Updated the `html_chunker.py` to accept `html_classes_to_exclude` in addition to `html_tags_to_exclude`.
   - The `__init__` method in the chunker class has been updated to initialize this new exclusion feature.
   - Modified the logic to ensure that text within these excluded classes is not included in the output passages.

This change helps refine the chunking process by giving more control over which parts of an HTML document should be excluded, particularly useful for content where certain classes (e.g., advertisements, navigation links, code blocks) should not be included in text processing. This change is backward-compatible as it only adds additional functionality without altering existing behavior unless the new `html_classes_to_exclude` parameter is used.


- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
